### PR TITLE
Remove DIRECTION_KEY_MODE, use per-page FZXC mapping and HAL utf8

### DIFF
--- a/projects/APPLaunch/main/include/keyboard_input.h
+++ b/projects/APPLaunch/main/include/keyboard_input.h
@@ -38,7 +38,7 @@ extern pthread_mutex_t keyboard_mutex;
 extern volatile int LVGL_HOME_KEY_FLAGE;
 extern volatile int LVGL_RUN_FLAGE;
 extern volatile uint32_t LV_EVENT_KEYBOARD;
-extern volatile int DIRECTION_KEY_MODE;
+
 void *keyboard_read_thread(void *argv);
 #ifdef __cplusplus
 }

--- a/projects/APPLaunch/main/src/keyboard_input.c
+++ b/projects/APPLaunch/main/src/keyboard_input.c
@@ -32,7 +32,8 @@ pthread_mutex_t keyboard_mutex = PTHREAD_MUTEX_INITIALIZER;
 volatile int LVGL_HOME_KEY_FLAGE = 0;
 volatile int LVGL_RUN_FLAGE = 1;
 volatile uint32_t LV_EVENT_KEYBOARD;
-volatile int DIRECTION_KEY_MODE = 1;
+
+
 #if !LV_USE_SDL
 /* ============================================================
  *  参数

--- a/projects/APPLaunch/main/src/main.cpp
+++ b/projects/APPLaunch/main/src/main.cpp
@@ -116,16 +116,6 @@ static void keypad_read_cb(lv_indev_t *indev, lv_indev_data_t *data)
             elm = STAILQ_FIRST(&keyboard_queue);
             STAILQ_REMOVE_HEAD(&keyboard_queue, entries);
 
-            if (DIRECTION_KEY_MODE) {
-                switch (elm->key_code) {
-                case KEY_F: elm->key_code = KEY_UP;    break;
-                case KEY_X: elm->key_code = KEY_DOWN;  break;
-                case KEY_Z: elm->key_code = KEY_LEFT;  break;
-                case KEY_C: elm->key_code = KEY_RIGHT; break;
-                default: break;
-                }
-            }
-
             printf("Read key event from queue: code=%u state=%u\n", elm->key_code, elm->key_state);
             lv_obj_t *root = lv_screen_active();
             if (root) {

--- a/projects/APPLaunch/main/ui/components/ui_app_IpPanel.hpp
+++ b/projects/APPLaunch/main/ui/components/ui_app_IpPanel.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "ui_app_page.hpp"
+#include "compat/input_keys.h"
 #include <unordered_map>
 #include <string>
 #include <vector>
@@ -298,10 +299,21 @@ private:
         UIIpPanelPage *self = static_cast<UIIpPanelPage *>(lv_event_get_user_data(e));
         if (self) self->event_handler(e);
     }
+    static uint32_t fzxc_to_lv_arrow(uint32_t key)
+    {
+        switch (key) {
+        case KEY_F: return LV_KEY_UP;
+        case KEY_X: return LV_KEY_DOWN;
+        case KEY_Z: return LV_KEY_LEFT;
+        case KEY_C: return LV_KEY_RIGHT;
+        default:    return key;
+        }
+    }
+
     void event_handler(lv_event_t *e)
     {
         if (lv_event_get_code(e) != LV_EVENT_KEY) return;
-        uint32_t key = lv_event_get_key(e);
+        uint32_t key = fzxc_to_lv_arrow(lv_event_get_key(e));
 
         int count = (int)iface_list_.size();
         switch (key)

--- a/projects/APPLaunch/main/ui/components/ui_app_chat.hpp
+++ b/projects/APPLaunch/main/ui/components/ui_app_chat.hpp
@@ -16,7 +16,6 @@
 //    - 底部文字输入区, 键盘输入字符, ENTER 发送
 //    - 发送后自动回复 (canned responses via LVGL timer)
 //    - BACKSPACE 删除末字符, ESC 返回主页
-//    - DIRECTION_KEY_MODE = 0 启用原始按键输入
 // ============================================================
 
 class UIchatPage : public app_base
@@ -30,7 +29,6 @@ class UIchatPage : public app_base
 public:
     UIchatPage() : app_base()
     {
-        DIRECTION_KEY_MODE = 0;
         creat_UI();
         event_handler_init();
         // seed a welcome message
@@ -44,7 +42,6 @@ public:
             lv_timer_delete(reply_timer_);
             reply_timer_ = nullptr;
         }
-        DIRECTION_KEY_MODE = 1;
     }
 
 private:
@@ -301,7 +298,6 @@ private:
     {
         switch (key) {
         case KEY_ESC:
-            DIRECTION_KEY_MODE = 1;
             if (go_back_home) go_back_home();
             return;
 

--- a/projects/APPLaunch/main/ui/components/ui_app_console.hpp
+++ b/projects/APPLaunch/main/ui/components/ui_app_console.hpp
@@ -69,7 +69,6 @@ public:
 public:
     UIConsolePage() : app_base()
     {
-        DIRECTION_KEY_MODE = 0;
         console_data_init();
         creat_console_UI();
         event_handler_init();
@@ -77,7 +76,6 @@ public:
 
     ~UIConsolePage()
     {
-        DIRECTION_KEY_MODE = 1;
         terminal_active = false;
         if (poll_timer)
         {

--- a/projects/APPLaunch/main/ui/components/ui_app_hack.hpp
+++ b/projects/APPLaunch/main/ui/components/ui_app_hack.hpp
@@ -272,7 +272,6 @@ private:
         port_hint_lbl_ = make_label(c, "Type IP, ENTER:scan  ESC:back", 0, 98, 0x555555, &lv_font_montserrat_10);
 
         // Enable text input mode
-        DIRECTION_KEY_MODE = 0;
         view_state_ = ViewState::INPUT;
     }
 
@@ -393,7 +392,6 @@ private:
     {
         if (view_state_ == ViewState::INPUT) {
             if (key == KEY_ESC) {
-                DIRECTION_KEY_MODE = 1;
                 view_state_ = ViewState::SUB;
                 close_sub_page();
                 return;
@@ -427,7 +425,6 @@ private:
                 lv_obj_scroll_by(port_result_cont_, 0, -20, LV_ANIM_ON);
             break;
         case KEY_ESC:
-            DIRECTION_KEY_MODE = 1;
             close_sub_page();
             break;
         default:
@@ -537,7 +534,6 @@ private:
 
         ping_hint_lbl_ = make_label(c, "Type host, ENTER:ping  ESC:back", 0, 98, 0x555555, &lv_font_montserrat_10);
 
-        DIRECTION_KEY_MODE = 0;
         view_state_ = ViewState::INPUT;
     }
 
@@ -617,7 +613,6 @@ private:
     {
         if (view_state_ == ViewState::INPUT) {
             if (key == KEY_ESC) {
-                DIRECTION_KEY_MODE = 1;
                 view_state_ = ViewState::SUB;
                 close_sub_page();
                 return;
@@ -650,7 +645,6 @@ private:
                 lv_obj_scroll_by(ping_result_cont_, 0, -20, LV_ANIM_ON);
             break;
         case KEY_ESC:
-            DIRECTION_KEY_MODE = 1;
             close_sub_page();
             break;
         default:
@@ -960,7 +954,6 @@ private:
             break;
 
         case KEY_ESC:
-            DIRECTION_KEY_MODE = 1;
             close_sub_page();
             break;
 

--- a/projects/APPLaunch/main/ui/components/ui_app_mesh.hpp
+++ b/projects/APPLaunch/main/ui/components/ui_app_mesh.hpp
@@ -54,7 +54,6 @@ public:
     ~UIMeshPage()
     {
         if (heartbeat_timer_) lv_timer_delete(heartbeat_timer_);
-        DIRECTION_KEY_MODE = 1;
     }
 
 private:
@@ -334,7 +333,6 @@ private:
     {
         view_state_ = ViewState::INPUT;
         msg_input_buf_.clear();
-        DIRECTION_KEY_MODE = 0;
 
         lv_obj_t *bg = ui_obj_["bg"];
 
@@ -366,7 +364,6 @@ private:
             input_overlay_ = nullptr;
         }
         msg_input_lbl_ = nullptr;
-        DIRECTION_KEY_MODE = 1;
         view_state_ = ViewState::MAIN;
     }
 

--- a/projects/APPLaunch/main/ui/components/ui_app_music.hpp
+++ b/projects/APPLaunch/main/ui/components/ui_app_music.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "ui_app_page.hpp"
+#include "compat/input_keys.h"
 #include <unordered_map>
 #include <string>
 #include <vector>
@@ -236,10 +237,21 @@ private:
         UIMusicPage *self = static_cast<UIMusicPage *>(lv_event_get_user_data(e));
         if (self) self->event_handler(e);
     }
+    static uint32_t fzxc_to_lv_arrow(uint32_t key)
+    {
+        switch (key) {
+        case KEY_F: return LV_KEY_UP;
+        case KEY_X: return LV_KEY_DOWN;
+        case KEY_Z: return LV_KEY_LEFT;
+        case KEY_C: return LV_KEY_RIGHT;
+        default:    return key;
+        }
+    }
+
     void event_handler(lv_event_t *e)
     {
         if (lv_event_get_code(e) != LV_EVENT_KEY) return;
-        uint32_t key = lv_event_get_key(e);
+        uint32_t key = fzxc_to_lv_arrow(lv_event_get_key(e));
         printf("[Music] key:%u  view:%d\n", key, (int)view_state_);
         switch (view_state_)
         {

--- a/projects/APPLaunch/main/ui/components/ui_app_setup.hpp
+++ b/projects/APPLaunch/main/ui/components/ui_app_setup.hpp
@@ -62,6 +62,7 @@ private:
     std::string wifi_pw_buf_;
     lv_obj_t *pw_input_lbl_ = nullptr;
     lv_obj_t *pw_hint_lbl_  = nullptr;
+    struct key_item *cur_elm_ = nullptr;
 
     // ---- Brightness sub-page state ----
     lv_obj_t *bright_bar_  = nullptr;
@@ -86,6 +87,17 @@ private:
     lv_obj_t *pwr_curr_lbl_ = nullptr;
     lv_obj_t *pwr_temp_lbl_ = nullptr;
     lv_obj_t *pwr_cap_lbl_  = nullptr;
+
+    static uint32_t fzxc_to_arrow(uint32_t key)
+    {
+        switch (key) {
+        case KEY_F: return KEY_UP;
+        case KEY_X: return KEY_DOWN;
+        case KEY_Z: return KEY_LEFT;
+        case KEY_C: return KEY_RIGHT;
+        default:    return key;
+        }
+    }
 
     // ==================== helper: styled label ====================
     static lv_obj_t *make_label(lv_obj_t *parent, const char *text,
@@ -320,7 +332,6 @@ private:
     void show_wifi_pw_input()
     {
         view_state_ = ViewState::WIFI_PW;
-        DIRECTION_KEY_MODE = 0;
         lv_obj_t *content = ui_obj_.count("sub_content") ? ui_obj_["sub_content"] : nullptr;
         if (!content) return;
         lv_obj_clean(content);
@@ -347,7 +358,6 @@ private:
     void handle_wifi_pw_key(uint32_t key)
     {
         if (key == KEY_ESC) {
-            DIRECTION_KEY_MODE = 1;
             view_state_ = ViewState::SUB;
             lv_obj_t *content = ui_obj_.count("sub_content") ? ui_obj_["sub_content"] : nullptr;
             if (content) {
@@ -360,7 +370,6 @@ private:
             if (pw_hint_lbl_)
                 lv_label_set_text(pw_hint_lbl_, "Connecting...");
             int ret = hal_wifi_connect(wifi_pw_ssid_.c_str(), wifi_pw_buf_.c_str());
-            DIRECTION_KEY_MODE = 1;
             view_state_ = ViewState::SUB;
             lv_obj_t *content = ui_obj_.count("sub_content") ? ui_obj_["sub_content"] : nullptr;
             if (content) {
@@ -377,28 +386,10 @@ private:
             wifi_pw_update_display();
             return;
         }
-        // printable characters: translate key_code to char
-        // key codes map to Linux input.h KEY_* values
-        char ch = keycode_to_char(key);
-        if (ch) {
-            wifi_pw_buf_ += ch;
+        if (cur_elm_ && cur_elm_->utf8[0]) {
+            wifi_pw_buf_ += cur_elm_->utf8;
             wifi_pw_update_display();
         }
-    }
-
-    static char keycode_to_char(uint32_t key)
-    {
-        // basic mapping for printable keys
-        if (key >= KEY_1 && key <= KEY_9) return '1' + (key - KEY_1);
-        if (key == KEY_0) return '0';
-        static const char qwerty[] = "qwertyuiop";
-        if (key >= KEY_Q && key <= KEY_P) return qwerty[key - KEY_Q];
-        static const char asdf[] = "asdfghjkl";
-        if (key >= KEY_A && key <= KEY_L) return asdf[key - KEY_A];
-        static const char zxcv[] = "zxcvbnm";
-        if (key >= KEY_Z && key <= KEY_M) return zxcv[key - KEY_Z];
-        if (key == KEY_SPACE) return ' ';
-        return 0;
     }
 
     void wifi_refresh_status()
@@ -894,11 +885,13 @@ private:
     {
         if(IS_KEY_RELEASED(e))
         {
-            uint32_t key = LV_EVENT_KEYBOARD_GET_KEY(e);
+            struct key_item *elm = (struct key_item *)lv_event_get_param(e);
+            cur_elm_ = elm;
+            uint32_t key = elm->key_code;
             switch (view_state_)
             {
-            case ViewState::MAIN:    handle_main_key(key); break;
-            case ViewState::SUB:     handle_sub_key(key);  break;
+            case ViewState::MAIN:    handle_main_key(fzxc_to_arrow(key)); break;
+            case ViewState::SUB:     handle_sub_key(fzxc_to_arrow(key));  break;
             case ViewState::WIFI_PW: handle_sub_key(key);  break;
             }
         }

--- a/projects/APPLaunch/main/ui/components/ui_app_ssh.hpp
+++ b/projects/APPLaunch/main/ui/components/ui_app_ssh.hpp
@@ -30,7 +30,6 @@ class UISSHPage : public app_base
 public:
     UISSHPage() : app_base()
     {
-        DIRECTION_KEY_MODE = 0;
         fields_.resize(3);
         fields_[0] = {"Host", "192.168.1.1"};
         fields_[1] = {"Port", "22"};
@@ -42,7 +41,6 @@ public:
     ~UISSHPage()
     {
         console_page_.reset();
-        DIRECTION_KEY_MODE = 1;
     }
 
 private:
@@ -230,7 +228,6 @@ private:
         auto self_go_home = this->go_back_home;
         console_page_->go_back_home = [this, self_go_home]() {
             // Return to the SSH input view
-            DIRECTION_KEY_MODE = 0;
             console_page_.reset();
             // Switch screen back to our root
             lv_disp_load_scr(this->get_ui());
@@ -290,7 +287,6 @@ private:
                 break;
 
             case KEY_ESC:
-                DIRECTION_KEY_MODE = 1;
                 if (go_back_home) go_back_home();
                 break;
 

--- a/projects/APPLaunch/main/ui/components/ui_app_stock.hpp
+++ b/projects/APPLaunch/main/ui/components/ui_app_stock.hpp
@@ -339,11 +339,22 @@ private:
         UIStockPage *self = static_cast<UIStockPage *>(lv_event_get_user_data(e));
         if (self) self->event_handler(e);
     }
+    static uint32_t fzxc_to_arrow(uint32_t key)
+    {
+        switch (key) {
+        case KEY_F: return KEY_UP;
+        case KEY_X: return KEY_DOWN;
+        case KEY_Z: return KEY_LEFT;
+        case KEY_C: return KEY_RIGHT;
+        default:    return key;
+        }
+    }
+
     void event_handler(lv_event_t *e)
     {
         if (IS_KEY_RELEASED(e))
         {
-            uint32_t key = LV_EVENT_KEYBOARD_GET_KEY(e);
+            uint32_t key = fzxc_to_arrow(LV_EVENT_KEYBOARD_GET_KEY(e));
             switch (view_state_) {
             case ViewState::MAIN: handle_main_key(key); break;
             case ViewState::SUB:  handle_sub_key(key);  break;

--- a/projects/APPLaunch/main/ui/components/ui_app_store.hpp
+++ b/projects/APPLaunch/main/ui/components/ui_app_store.hpp
@@ -537,15 +537,24 @@ private:
     }
 
 
+    static uint32_t fzxc_to_arrow(uint32_t key)
+    {
+        switch (key) {
+        case KEY_F: return KEY_UP;
+        case KEY_X: return KEY_DOWN;
+        case KEY_Z: return KEY_LEFT;
+        case KEY_C: return KEY_RIGHT;
+        default:    return key;
+        }
+    }
+
     void event_handler(lv_event_t *e)
     {
         // lv_event_code_t event_code = lv_event_get_code(e);
         if (IS_KEY_RELEASED(e))
         {
-            uint32_t key = LV_EVENT_KEYBOARD_GET_KEY(e);
-
-
-            printf("Enter key:%d\n", key);
+            uint32_t key = fzxc_to_arrow(LV_EVENT_KEYBOARD_GET_KEY(e));
+            printf("[store] key released: %d\n", key);
 
             // ---- 详情面板模式 ----
             if (in_detail_view_)

--- a/projects/APPLaunch/main/ui/ui_events.c
+++ b/projects/APPLaunch/main/ui/ui_events.c
@@ -302,13 +302,25 @@ void app_launch(lv_event_t *e)
     cpp_app_launch();
 }
 
+static uint32_t fzxc_to_arrow(uint32_t key)
+{
+    switch (key) {
+    case KEY_F: return KEY_UP;
+    case KEY_X: return KEY_DOWN;
+    case KEY_Z: return KEY_LEFT;
+    case KEY_C: return KEY_RIGHT;
+    default:    return key;
+    }
+}
+
 void main_key_switch(lv_event_t *e)
 {
 
     struct key_item *elm = (struct key_item *)lv_event_get_param(e);
+    uint32_t code = fzxc_to_arrow(elm->key_code);
     if (elm->key_state)
     {
-        switch (elm->key_code)
+        switch (code)
         {
         case KEY_UP:
             break;
@@ -324,7 +336,7 @@ void main_key_switch(lv_event_t *e)
             break;
         }
     }
-    else if (elm->key_code == KEY_ENTER)
+    else if (code == KEY_ENTER)
     {
         app_launch(NULL);
     }


### PR DESCRIPTION
## Summary
- 删除全局 `DIRECTION_KEY_MODE` 变量及 `keypad_read_cb` 中的公共 FZXC→方向键转换
- 各页面自行做局部 FZXC→方向键映射（static util 函数）
- WiFi 密码输入改用 HAL 层提供的 `elm->utf8`，替代自写的 `keycode_to_char()`，修复 CM0 上符号键（`!@#$%^&*` 等）无法输入的问题
- Console 页面不再切换 `DIRECTION_KEY_MODE`（直接使用原始 keycode+utf8）

## 改动文件
- `keyboard_input.h` / `keyboard_input.c` — 删除 DIRECTION_KEY_MODE
- `main.cpp` — 删除 keypad_read_cb 中的转换逻辑
- `ui_app_setup.hpp` — 局部 fzxc_to_arrow + utf8 输入
- `ui_app_stock.hpp` / `ui_app_store.hpp` — 局部 fzxc_to_arrow
- `ui_app_music.hpp` / `ui_app_IpPanel.hpp` — 局部 fzxc_to_lv_arrow
- `ui_app_console.hpp` — 移除 DIRECTION_KEY_MODE 赋值
- `ui_events.c` — 主页导航局部 fzxc_to_arrow

## Test plan
- [ ] 主页左右切换 app 正常（Z/C 键）
- [ ] Settings 页面上下导航正常（F/X 键）
- [ ] WiFi 密码输入：字母、数字、符号（!@#$%^&*）均可输入
- [ ] Console 终端键盘输入正常
- [ ] Music / Store / Stock / IpPanel 页面方向键导航正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)