### PR TITLE
UI: add loading overlay on app launch

### DIFF
--- a/projects/APPLaunch/main/ui/components/ui_app_launch.cpp
+++ b/projects/APPLaunch/main/ui/components/ui_app_launch.cpp
@@ -33,6 +33,7 @@
 #include "ui_app_rec.hpp"
 #include "ui_app_camera.hpp"
 #include "ui_app_game.hpp"
+#include "../ui_loading.h"
 
 static inline std::string img_path(const char *name)
 {
@@ -260,18 +261,31 @@ public:
     void launch_Exec_in_terminal(const std::string &exec, bool sysplause = true)
     {
         printf("Launching terminal app: %s\n", exec.c_str());
+        /* Instant visual feedback; paint before the (potentially slow)
+         * Console page construction so the user sees it right away. */
+        ui_loading_show("Loading...");
+        lv_refr_now(NULL);
         auto p = std::make_shared<UIConsolePage>();
         app_Page = p;
         lv_disp_load_scr(p->get_ui());
         lv_indev_set_group(lv_indev_get_next(NULL), p->get_key_group());
         p->go_back_home = std::bind(&app_launch_S::go_back_home, this);
         p->terminal_sysplause = sysplause;
+        /* Console page fully covers APP_Container; safe to hide now.
+         * The heavy exec() call below will still run while the terminal
+         * page is on-screen — no overlay needed at that point. */
+        ui_loading_hide();
         p->exec(exec);
     }
 
     void launch_Exec(const std::string &exec)
     {
         printf("Launching external app: %s\n", exec.c_str());
+        /* Show overlay BEFORE we tear down LVGL input/timers so the user
+         * gets immediate feedback when ENTER was pressed. The overlay
+         * stays drawn on the framebuffer right up until the child takes
+         * it over via hal_process_exec_blocking(). */
+        ui_loading_show("Loading...");
         lv_disp_t *disp = lv_disp_get_default();
         lv_indev_t *indev = lv_indev_get_next(NULL);
         LVGL_RUN_FLAGE = 0;
@@ -286,6 +300,9 @@ public:
         if (indev)
             lv_indev_set_group(indev, Screen1group);
         lv_disp_load_scr(ui_Screen1);
+        /* Child process has returned; we are back on the launcher home.
+         * Hide the overlay so it doesn't linger. */
+        ui_loading_hide();
         lv_obj_invalidate(lv_screen_active());
         lv_refr_now(disp);
         LVGL_RUN_FLAGE = 1;
@@ -605,6 +622,13 @@ app::app(std::string name,
 {
     launch = [](app_launch_S *self)
     {
+        /* Instant feedback: show the overlay, then force an immediate
+         * redraw so it actually paints BEFORE the (sometimes slow) page
+         * construction starts. Without lv_refr_now() the overlay would
+         * only hit the framebuffer after the constructor returns, which
+         * defeats the whole point. */
+        ui_loading_show("Loading...");
+        lv_refr_now(NULL);
         auto p = std::make_shared<PageT>();
         self->app_Page = p;
         lv_disp_load_scr(p->get_ui());
@@ -612,6 +636,9 @@ app::app(std::string name,
                            p->get_key_group());
         p->go_back_home =
             std::bind(&app_launch_S::go_back_home, self);
+        /* Page is now attached and drawable; hide the overlay. The
+         * next LVGL frame will paint the new page without it. */
+        ui_loading_hide();
     };
 }
 

--- a/projects/APPLaunch/main/ui/ui_loading.cpp
+++ b/projects/APPLaunch/main/ui/ui_loading.cpp
@@ -1,0 +1,114 @@
+/*
+ * ui_loading.cpp
+ *
+ * Transient "Loading..." overlay for app launches.
+ *
+ * Created lazily on first ui_loading_show() call as a child of
+ * lv_layer_top() so it floats above any screen. Never deleted;
+ * visibility is toggled via LV_OBJ_FLAG_HIDDEN. An lv_spinner sits
+ * to the left of a short text label, both centered on-screen inside
+ * a dark semi-transparent pill — matching the look of the hint toast
+ * in ui_global_hint.cpp.
+ *
+ * Design notes:
+ *   - Because internal page construction happens synchronously on the
+ *     LVGL thread, callers should follow ui_loading_show() with
+ *     lv_refr_now(NULL) to force the overlay to actually paint BEFORE
+ *     the slow work begins. Otherwise LVGL would only render on the
+ *     next frame, which is after the freeze.
+ *   - For external (forked) apps, lv_refr_now() is already performed
+ *     by launch_Exec() before hal_process_exec_blocking() — the
+ *     overlay stays on-screen while the child owns the framebuffer,
+ *     which is exactly the desired "something is happening" feedback.
+ */
+
+#include "ui_loading.h"
+#include "ui.h"
+#include "lvgl/lvgl.h"
+
+#define LOADING_BG_COLOR    0x1F3A5F
+#define LOADING_BG_OPA      LV_OPA_80
+#define LOADING_TEXT_COLOR  0xFFFFFF
+#define LOADING_WIDTH       200
+#define LOADING_HEIGHT      40
+#define LOADING_SPINNER_SZ  24
+
+static lv_obj_t *s_loading_obj     = NULL;
+static lv_obj_t *s_loading_spinner = NULL;
+static lv_obj_t *s_loading_label   = NULL;
+
+static void ensure_loading_created(void)
+{
+    if (s_loading_obj != NULL) return;
+
+    lv_obj_t *parent = lv_layer_top();
+    if (parent == NULL) return;
+
+    s_loading_obj = lv_obj_create(parent);
+    lv_obj_remove_style_all(s_loading_obj);
+    lv_obj_set_size(s_loading_obj, LOADING_WIDTH, LOADING_HEIGHT);
+    lv_obj_center(s_loading_obj);
+
+    lv_obj_set_style_bg_color(s_loading_obj, lv_color_hex(LOADING_BG_COLOR), 0);
+    lv_obj_set_style_bg_opa(s_loading_obj, LOADING_BG_OPA, 0);
+    lv_obj_set_style_radius(s_loading_obj, 8, 0);
+    lv_obj_set_style_border_width(s_loading_obj, 0, 0);
+    lv_obj_set_style_pad_all(s_loading_obj, 6, 0);
+    lv_obj_set_style_shadow_width(s_loading_obj, 0, 0);
+
+    /* Purely visual — never steal focus or clicks. */
+    lv_obj_clear_flag(s_loading_obj, LV_OBJ_FLAG_CLICKABLE);
+    lv_obj_clear_flag(s_loading_obj, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_flag(s_loading_obj, LV_OBJ_FLAG_IGNORE_LAYOUT);
+
+    /* Horizontal layout: spinner on the left, label to its right. */
+    lv_obj_set_flex_flow(s_loading_obj, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(s_loading_obj,
+                          LV_FLEX_ALIGN_CENTER,
+                          LV_FLEX_ALIGN_CENTER,
+                          LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_pad_column(s_loading_obj, 8, 0);
+
+    /* Spinner — 1s arc, 60 degrees long. */
+    s_loading_spinner = lv_spinner_create(s_loading_obj);
+    lv_obj_set_size(s_loading_spinner, LOADING_SPINNER_SZ, LOADING_SPINNER_SZ);
+    lv_spinner_set_anim_params(s_loading_spinner, 1000, 60);
+    lv_obj_set_style_arc_width(s_loading_spinner, 3, LV_PART_MAIN);
+    lv_obj_set_style_arc_width(s_loading_spinner, 3, LV_PART_INDICATOR);
+    lv_obj_set_style_arc_color(s_loading_spinner,
+                               lv_color_hex(0x3B6FA0), LV_PART_MAIN);
+    lv_obj_set_style_arc_color(s_loading_spinner,
+                               lv_color_hex(LOADING_TEXT_COLOR),
+                               LV_PART_INDICATOR);
+
+    s_loading_label = lv_label_create(s_loading_obj);
+    lv_obj_set_style_text_color(s_loading_label,
+                                lv_color_hex(LOADING_TEXT_COLOR), 0);
+    /* Use the project's 14pt font with montserrat fallback — matches
+     * the sizing of the existing hint overlay's copy. */
+    lv_font_t *font = g_font_cn_14 ? g_font_cn_14
+                                   : (lv_font_t *)&lv_font_montserrat_14;
+    lv_obj_set_style_text_font(s_loading_label, font, 0);
+    lv_label_set_text(s_loading_label, "");
+
+    lv_obj_add_flag(s_loading_obj, LV_OBJ_FLAG_HIDDEN);
+}
+
+extern "C" void ui_loading_show(const char *label)
+{
+    ensure_loading_created();
+    if (s_loading_obj == NULL || s_loading_label == NULL) return;
+
+    lv_label_set_text(s_loading_label,
+                      (label && label[0]) ? label : "Loading...");
+    /* Make sure the overlay stays on top of any other lv_layer_top
+     * children (e.g. the ui_global_hint toast). */
+    lv_obj_move_foreground(s_loading_obj);
+    lv_obj_clear_flag(s_loading_obj, LV_OBJ_FLAG_HIDDEN);
+}
+
+extern "C" void ui_loading_hide(void)
+{
+    if (s_loading_obj == NULL) return;
+    lv_obj_add_flag(s_loading_obj, LV_OBJ_FLAG_HIDDEN);
+}

--- a/projects/APPLaunch/main/ui/ui_loading.h
+++ b/projects/APPLaunch/main/ui/ui_loading.h
@@ -1,0 +1,41 @@
+/*
+ * ui_loading.h
+ *
+ * Global "Loading..." overlay used to give instant visual feedback when
+ * the user activates an app entry on the launcher home.
+ *
+ * The overlay is a lazily-created child of lv_layer_top(), so it floats
+ * above any screen and survives lv_disp_load_scr() transitions. It is
+ * never deleted — only toggled via LV_OBJ_FLAG_HIDDEN — which mirrors
+ * the pattern established by ui_global_hint.cpp.
+ *
+ * Typical usage from the launcher:
+ *
+ *   ui_loading_show("Loading...");
+ *   lv_refr_now(NULL);   // force the overlay to paint *before* the
+ *                        //   (possibly slow) page construction below
+ *   auto p = std::make_shared<PageT>();
+ *   lv_disp_load_scr(p->get_ui());
+ *   ui_loading_hide();
+ */
+#ifndef UI_LOADING_H
+#define UI_LOADING_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Show the loading overlay with the given label. Idempotent: calling
+ * repeatedly just updates the text. Safe to call before LVGL is fully
+ * initialised (no-op if lv_layer_top() is not yet available).
+ */
+void ui_loading_show(const char *label);
+
+/* Hide the loading overlay. Safe to call when not shown (no-op). */
+void ui_loading_hide(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UI_LOADING_H */


### PR DESCRIPTION
## Summary
- Instant visual feedback when ENTER is pressed on the launcher home
- New `ui_loading_show()` / `ui_loading_hide()` API, same never-delete pattern as `ui_global_hint`
- Wired into both internal LVGL page construction and external process launch paths
- Uses `lv_refr_now()` before the slow work so the overlay actually paints before the freeze

## Test plan
- [x] Built on CI (APPLauncher aarch64)
- [x] Verified on CM0 device — overlay visible when launching apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)