### PR TITLE
Remove noisy evdev keymap dump on startup

### DIFF
--- a/projects/APPLaunch/main/src/main.cpp
+++ b/projects/APPLaunch/main/src/main.cpp
@@ -305,8 +305,6 @@ int main(void)
 
     LV_EVENT_KEYBOARD = lv_event_register_id();
 
-    kbd_dump_keymap_table();
-
     ui_init();
     // lv_demo_widgets(); // 用LVGL自带demo测试
     /*Handle LVGL tasks*/


### PR DESCRIPTION
## Summary
- Drops the ~60-line \`[KBD] evdev key_code -> label table\` dump that fires every boot
- The helper function itself stays in \`keyboard_input.c\` for manual use

🤖 Generated with [Claude Code](https://claude.com/claude-code)