### PR TITLE
Fix emulator Windows build: guard Linux-only i2c/ioctl headers

### DIFF
--- a/projects/APPLaunch/main/ui/components/ui_app_hack.hpp
+++ b/projects/APPLaunch/main/ui/components/ui_app_hack.hpp
@@ -7,12 +7,11 @@
 #include <algorithm>
 #include <cstdio>
 #include <cstring>
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
 #include <unistd.h>
-#include "hal/hal_settings.h"
-#include "hal/hal_network.h"
-#include "compat/input_keys.h"
-
-#ifndef _WIN32
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -20,6 +19,9 @@
 #include <errno.h>
 #include <sys/select.h>
 #endif
+#include "hal/hal_settings.h"
+#include "hal/hal_network.h"
+#include "compat/input_keys.h"
 
 // ============================================================
 //  HACK Tools  UIHackPage

--- a/projects/APPLaunch/main/ui/components/ui_app_setup.hpp
+++ b/projects/APPLaunch/main/ui/components/ui_app_setup.hpp
@@ -8,11 +8,15 @@
 #include <cstring>
 #include <cstdlib>
 #include <fcntl.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 #include <dirent.h>
+#ifdef __linux__
 #include <sys/ioctl.h>
 #include <linux/i2c.h>
 #include <linux/i2c-dev.h>
+#endif
 #include "hal/hal_settings.h"
 
 // ============================================================
@@ -1029,6 +1033,7 @@ private:
 
     static int bq27220_control_cmd(int cmd)
     {
+#ifdef __linux__
         int fd = open(BQ27220_I2C_DEV, O_RDWR);
         if (fd < 0) return -1;
 
@@ -1048,6 +1053,10 @@ private:
         int ret = ioctl(fd, I2C_RDWR, &data);
         close(fd);
         return ret < 0 ? -1 : 0;
+#else
+        (void)cmd;
+        return -1;
+#endif
     }
 
     // ==================== UI 构建（主菜单） ====================

--- a/projects/CardputerZero-Emulator/CMakeLists.txt
+++ b/projects/CardputerZero-Emulator/CMakeLists.txt
@@ -295,6 +295,9 @@ if(NOT WIN32)
     target_link_libraries(cardputer-zero-emu PRIVATE ${CMAKE_DL_LIBS})
     find_package(Threads REQUIRED)
     target_link_libraries(cardputer-zero-emu PRIVATE Threads::Threads)
+else()
+    # ui_app_hack.hpp calls gethostname() on Windows via <winsock2.h>.
+    target_link_libraries(cardputer-zero-emu PRIVATE ws2_32)
 endif()
 
 # ---------------------------------------------------------------------------

--- a/projects/CardputerZero-Emulator/src/main.cpp
+++ b/projects/CardputerZero-Emulator/src/main.cpp
@@ -255,6 +255,13 @@ extern "C" {
     void ui_init(void);
     void lv_sdl_keyboard_handler(SDL_Event *event);
 }
+// APPLaunch's src/main.cpp defines LV_EVENT_BATTERY, but the Windows
+// static build doesn't compile that file — provide a stub here so the
+// UI code that references it links. (Never fired on emulator.)
+#if defined(_WIN32) && defined(EMU_STATIC_APP)
+#include <cstdint>
+extern "C" volatile uint32_t LV_EVENT_BATTERY = 0;
+#endif
 #endif
 
 // Set working directory to the exe's directory so relative paths work

--- a/projects/CardputerZero-Emulator/src/main_web.cpp
+++ b/projects/CardputerZero-Emulator/src/main_web.cpp
@@ -14,6 +14,10 @@
 
 extern "C" { void ui_init(void); }
 
+// APPLaunch's main.cpp defines LV_EVENT_BATTERY, but the web target
+// uses this main_web.cpp instead, so the symbol would be undefined.
+volatile uint32_t LV_EVENT_BATTERY;
+
 // ── Layout (same as native) ─────────────────────────────────────
 static constexpr int SKIN_W = 1280;
 static constexpr int SKIN_H = 840;


### PR DESCRIPTION
## Summary
- MinGW's emulator build fails because `ui_app_setup.hpp` includes `<sys/ioctl.h>` and `<linux/i2c*.h>`, which don't exist on Windows
- Guard those includes and the `bq27220_control_cmd` body behind `__linux__`, and skip `<unistd.h>` on `_WIN32`
- macOS / Linux paths unchanged; Windows build gets a `-1` stub for the i2c control cmd

## Test plan
- [x] macOS local cmake build passes (`cmake --build …/CardputerZero-Emulator/build`)
- [ ] Windows (MinGW) CI build passes
- [ ] Linux CI build still passes
- [ ] Web (Emscripten) CI build still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)