### PR TITLE
Fix startup GIF hijacking screen + wasting CPU

### DIFF
--- a/projects/APPLaunch/main/ui/ui.c
+++ b/projects/APPLaunch/main/ui/ui.c
@@ -169,8 +169,12 @@ void home_screen_load()
 }
 
 void ui_event_logo_over(lv_event_t * e) {
+    static int done = 0;
     lv_event_code_t event_code = lv_event_get_code(e);
-    if(event_code == LV_EVENT_READY) {
+    if(event_code == LV_EVENT_READY && !done) {
+        done = 1;
+        printf("[GIF] first LV_EVENT_READY -> pause + home_screen_load()\n");
+        if (startup_gif) lv_gif_pause(startup_gif);
         home_screen_load();
     }
 }


### PR DESCRIPTION
## Summary
- Startup GIF looped forever, and each LV_EVENT_READY silently called home_screen_load() — any page the user was on (Settings/Console/Music) got yanked back to home every ~10s
- Only reproduced under systemd because manual runs have a different cwd and never find the GIF
- Also kept decoding frames on lv_timer the whole time, wasting CPU

## Fix
- ui_event_logo_over is now one-shot via a static flag
- lv_gif_pause() on first completion so the decode loop stops

Verified on device — Settings/Console/Music no longer auto-return to home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)