### PR TITLE
fix CI: APPLauncher and Emulator build errors

### DIFF
--- a/projects/APPLaunch/main/ui/components/page_app/ui_app_gallery.hpp
+++ b/projects/APPLaunch/main/ui/components/page_app/ui_app_gallery.hpp
@@ -40,7 +40,11 @@ class UIGalleryPage : public app_base
 public:
     UIGalleryPage() : app_base()
     {
+#ifdef _WIN32
+        mkdir(TMP_DIR);
+#else
         mkdir(TMP_DIR, 0755);
+#endif
         scan_images();
         create_UI();
         event_handler_init();

--- a/projects/APPLaunch/main/ui/components/page_app/ui_app_hikepod.hpp
+++ b/projects/APPLaunch/main/ui/components/page_app/ui_app_hikepod.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#if !defined(HAL_PLATFORM_SDL)
 #include "../ui_app_page.hpp"
 #include "TinyGPS++.h"
 #include <fcntl.h>
@@ -907,3 +908,4 @@ private:
 //         // so we do not render individual satellite dots unless satellites_ is populated elsewhere.
 //     }
 // };
+#endif // !HAL_PLATFORM_SDL

--- a/projects/APPLaunch/main/ui/components/ui_app_launch.cpp
+++ b/projects/APPLaunch/main/ui/components/ui_app_launch.cpp
@@ -108,9 +108,11 @@ public:
                               true,
                               false);
 
+#if !defined(HAL_PLATFORM_SDL)
         app_list.emplace_back("SETTING",
                               img_path("SETTING_80.png"),
                               page_v<UISetupPage>);
+#endif
 
         app_list.emplace_back("STORE",
                               img_path("STORE_80.png"),
@@ -218,9 +220,11 @@ public:
                               img_path("REC_80.png"),
                               page_v<UIRecPage>);
 
+#if !defined(HAL_PLATFORM_SDL)
         app_list.emplace_back("CAMERA",
                               img_path("CAMERA_80.png"),
                               page_v<UICameraPage>);
+#endif
 
         app_list.emplace_back("GAME",
                               img_path("GAME_80.png"),
@@ -238,17 +242,21 @@ public:
                               img_path("Gpio_80.png"),
                               page_v<UIGpioPage>);
 
+#if !defined(HAL_PLATFORM_SDL)
         app_list.emplace_back("LoRa",
                               img_path("LoRa_80.png"),
                               page_v<UILoraPage>);
+#endif
 
         app_list.emplace_back("GALLERY",
                               img_path("GALLERY_80.png"),
                               page_v<UIGalleryPage>);
 
+#if !defined(HAL_PLATFORM_SDL)
         app_list.emplace_back("NAVI",
                               img_path("HIKEPOD_80.png"),
                               page_v<UIHikePodPage>);
+#endif
 
         // app_list.emplace_back("AICli",
         //                       img_path("AICli_80.png"),

--- a/projects/CardputerZero-Emulator/CMakeLists.txt
+++ b/projects/CardputerZero-Emulator/CMakeLists.txt
@@ -133,7 +133,6 @@ add_library(APPLaunch SHARED
 target_include_directories(APPLaunch PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/vendor
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/compat
     ${CMAKE_CURRENT_SOURCE_DIR}/lib
     ${REPO_ROOT}/ext_components/Miniaudio/include
     ${APPLAUNCH}/ui
@@ -141,6 +140,11 @@ target_include_directories(APPLaunch PRIVATE
     ${APPLAUNCH}
     ${APPLAUNCH}/hal
 )
+if(NOT WIN32)
+    target_include_directories(APPLaunch PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/compat_stubs)
+else()
+    target_include_directories(APPLaunch PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/compat)
+endif()
 target_compile_definitions(APPLaunch PRIVATE HAL_PLATFORM_SDL=1)
 if(SDL2_MIXER_FOUND)
     target_compile_definitions(APPLaunch PRIVATE EMU_HAS_AUDIO=1)
@@ -351,7 +355,7 @@ if(EMSCRIPTEN)
         ${CMAKE_CURRENT_SOURCE_DIR}/src/compat_queue
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}/src
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/compat
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/compat_stubs
         ${CMAKE_CURRENT_SOURCE_DIR}/vendor
         ${CMAKE_CURRENT_SOURCE_DIR}/lib
         ${REPO_ROOT}/ext_components/Miniaudio/include

--- a/projects/CardputerZero-Emulator/CMakeLists.txt
+++ b/projects/CardputerZero-Emulator/CMakeLists.txt
@@ -114,7 +114,7 @@ option(EMU_SKIP_APPLAUNCH "Skip APPLaunch (Unix-only deps)" OFF)
 
 file(GLOB_RECURSE APPLAUNCH_UI_C   ${APPLAUNCH}/ui/*.c)
 file(GLOB_RECURSE APPLAUNCH_UI_CPP ${APPLAUNCH}/ui/*.cpp)
-file(GLOB         APPLAUNCH_KBD    ${APPLAUNCH}/src/keyboard_input.c)
+file(GLOB         APPLAUNCH_KBD    ${APPLAUNCH}/hal/keyboard_input.c)
 file(GLOB APPLAUNCH_HAL_SDL_C   ${APPLAUNCH}/hal/sdl/*.c)
 file(GLOB APPLAUNCH_HAL_SDL_CPP ${APPLAUNCH}/hal/sdl/*.cpp)
 
@@ -336,7 +336,7 @@ endif() # NOT EMSCRIPTEN
 if(EMSCRIPTEN)
     file(GLOB_RECURSE APPLAUNCH_UI_C_WEB   ${APPLAUNCH}/ui/*.c)
     file(GLOB_RECURSE APPLAUNCH_UI_CPP_WEB ${APPLAUNCH}/ui/*.cpp)
-    file(GLOB         APPLAUNCH_KBD_WEB    ${APPLAUNCH}/src/keyboard_input.c)
+    file(GLOB         APPLAUNCH_KBD_WEB    ${APPLAUNCH}/hal/keyboard_input.c)
     file(GLOB         APPLAUNCH_HAL_SDL_C_WEB   ${APPLAUNCH}/hal/sdl/*.c)
     file(GLOB         APPLAUNCH_HAL_SDL_CPP_WEB ${APPLAUNCH}/hal/sdl/*.cpp)
 

--- a/projects/CardputerZero-Emulator/CMakeLists.txt
+++ b/projects/CardputerZero-Emulator/CMakeLists.txt
@@ -315,7 +315,7 @@ add_custom_command(TARGET cardputer-zero-emu POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:UserDemo> $<TARGET_FILE_DIR:cardputer-zero-emu>/apps/
     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:cardputer-zero-emu>/applications
     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:cardputer-zero-emu>/images
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${APPLAUNCH}/ui/images $<TARGET_FILE_DIR:cardputer-zero-emu>/images
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${REPO_ROOT}/projects/APPLaunch/APPLaunch/share/images $<TARGET_FILE_DIR:cardputer-zero-emu>/images
     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:cardputer-zero-emu>/assets
     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/assets/device_skin.png $<TARGET_FILE_DIR:cardputer-zero-emu>/assets/device_skin.png
     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/assets/startup.mp3 $<TARGET_FILE_DIR:cardputer-zero-emu>/assets/startup.mp3
@@ -383,7 +383,7 @@ if(EMSCRIPTEN)
         -sALLOW_MEMORY_GROWTH=1
         -sINITIAL_MEMORY=67108864
         "--preload-file=${CMAKE_CURRENT_SOURCE_DIR}/assets/device_skin.png@/assets/device_skin.png"
-        "--preload-file=${APPLAUNCH}/ui/images@/images"
+        "--preload-file=${REPO_ROOT}/projects/APPLaunch/APPLaunch/share/images@/images"
         --shell-file ${CMAKE_CURRENT_SOURCE_DIR}/web/shell.html
     )
 

--- a/projects/CardputerZero-Emulator/src/compat_stubs/thpool.h
+++ b/projects/CardputerZero-Emulator/src/compat_stubs/thpool.h
@@ -1,0 +1,6 @@
+#pragma once
+#include <stddef.h>
+typedef void *threadpool;
+static inline threadpool thpool_init(int num) { (void)num; return NULL; }
+static inline int thpool_add_work(threadpool tp, void (*fn)(void*), void *arg) { (void)tp; if(fn) fn(arg); return 0; }
+static inline void thpool_destroy(threadpool tp) { (void)tp; }


### PR DESCRIPTION
## Summary
- **APPLauncher (scons)**: add `wget_github()` function to download RadioLib and C-Thread-Pool; replace removed `FEC.cpp` with `ConvCode.cpp`
- **Emulator (CMake)**: add miniaudio include path, thpool stub, guard Linux-only apps (`camera`, `lora`, `setup`, `hikepod`) with `!HAL_PLATFORM_SDL`, fix `keyboard_input.c` path (moved to `hal/`), update images path, fix `mkdir` on Windows, add Emscripten stubs for `waitpid`/`fork`

## Test plan
- [x] Build APPLauncher CI passes
- [x] Build Emulator CI passes (macOS, Linux, Windows, Web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)