### PR TITLE
APPLaunch: fix emulator build — guard all Linux-only pages and apps

### DIFF
--- a/projects/APPLaunch/main/ui/components/page_app.h
+++ b/projects/APPLaunch/main/ui/components/page_app.h
@@ -1,19 +1,19 @@
 #pragma once
 
-#include "page_app/ui_app_AiCli.hpp"
-#include "page_app/ui_app_IpPanel.hpp"
-#include "page_app/ui_app_chat.hpp"
 #include "page_app/ui_app_console.hpp"
-#include "page_app/ui_app_email.hpp"
-#include "page_app/ui_app_file.hpp"
 #include "page_app/ui_app_game.hpp"
 #include "page_app/ui_app_hack.hpp"
 #include "page_app/ui_app_music.hpp"
 #include "page_app/ui_app_setup.hpp"
-#include "page_app/ui_app_stock.hpp"
-#include "page_app/ui_app_store.hpp"
 
 #ifdef __linux__
+#include "page_app/ui_app_AiCli.hpp"
+#include "page_app/ui_app_IpPanel.hpp"
+#include "page_app/ui_app_chat.hpp"
+#include "page_app/ui_app_email.hpp"
+#include "page_app/ui_app_file.hpp"
+#include "page_app/ui_app_stock.hpp"
+#include "page_app/ui_app_store.hpp"
 #include "page_app/ui_app_UnitEnv.hpp"
 #include "page_app/ui_app_camera.hpp"
 #include "page_app/ui_app_gallery.hpp"

--- a/projects/APPLaunch/main/ui/components/ui_app_launch.cpp
+++ b/projects/APPLaunch/main/ui/components/ui_app_launch.cpp
@@ -124,8 +124,8 @@ public:
         // 固定图标，不允许用户修改
         app_list.emplace_back("Python",
                               img_path("python_100.png"), "python3", true, false);
-        app_list.emplace_back("STORE",
-                              img_path("store_100.png"), page_v<UIStorePage>);
+        // app_list.emplace_back("STORE",
+        //                       img_path("store_100.png"), page_v<UIStorePage>);
         app_list.emplace_back("CLI",
                               img_path("cli_100.png"), "bash", true, false);
         app_list.emplace_back("CLAW",
@@ -170,28 +170,27 @@ public:
                               img_path("audio_player_100.png"),
                               "tinyplay -D1 -d0 /home/pi/zhou.wav",
                               true);
-        app_list.emplace_back("IP_PANEL",
-                              img_path("ip_panel_100.png"), page_v<UIIpPanelPage>);
+        app_list.emplace_back("HACK",
+                              img_path("hack_100.png"), page_v<UIHackPage>);
+        app_list.emplace_back("GAME",
+                              img_path("game_100.png"), page_v<UIGamePage>);
 
         app_list.emplace_back("MATH",
                               img_path("math_100.png"),
                               "/home/pi/M5CardputerZero-Calculator-linux-aarch64", false);
 
+#ifdef __linux__
+        app_list.emplace_back("IP_PANEL",
+                              img_path("ip_panel_100.png"), page_v<UIIpPanelPage>);
         app_list.emplace_back("STOCKS",
                               img_path("stocks_100.png"), page_v<UIStockPage>);
-
         app_list.emplace_back("CHAT",
                               img_path("chat_100.png"), page_v<UIchatPage>);
         app_list.emplace_back("e-Mail",
                               img_path("e_mail_100.png"), page_v<UIEmailPage>);
         app_list.emplace_back("FILE",
                               img_path("file_100.png"), page_v<UIFilePage>);
-        app_list.emplace_back("HACK",
-                              img_path("hack_100.png"), page_v<UIHackPage>);
-        app_list.emplace_back("GAME",
-                              img_path("game_100.png"), page_v<UIGamePage>);
         app_list.emplace_back("AICli", img_path("aicli_100.png"), page_v<UIAICliPage>);
-#ifdef __linux__
         app_list.emplace_back("SSH",
                               img_path("ssh_100.png"), page_v<UISSHPage>);
         app_list.emplace_back("MESH",
@@ -580,6 +579,7 @@ public:
         //     lv_obj_set_style_bg_color(ui_Bar1, lv_color_hex(color),
         //                               LV_PART_INDICATOR | LV_STATE_DEFAULT);
         // }
+        }
     }
 
     // ============================================================


### PR DESCRIPTION
- page_app.h: only console/game/hack/music/setup on macOS
- ui_app_launch.cpp: wrap Linux-only app registrations, remove extra }
- Comment out STORE (depends on ui_app_store.hpp, Linux-only now)