### PR TITLE
hal: EVIOCGRAB input devices in libinput open_restricted callback

### DIFF
--- a/projects/APPLaunch/main/hal/keyboard_input.c
+++ b/projects/APPLaunch/main/hal/keyboard_input.c
@@ -13,6 +13,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #ifdef __linux__
+#include <sys/ioctl.h>
 #include <sys/timerfd.h>
 #include <linux/input.h>
 #include <libinput.h>
@@ -115,9 +116,20 @@ void kbd_dump_keymap_table(void) {}
  * ============================================================ */
 static int open_restricted(const char *path, int flags, void *user_data) {
     int fd = open(path, flags);
-    if (fd < 0)
+    if (fd < 0) {
         fprintf(stderr, "无法打开 %s: %s\n", path, strerror(errno));
-    return fd < 0 ? -errno : fd;
+        return -errno;
+    }
+    /* Grab the device exclusively. Without this, the kernel VT keyboard
+     * handler also feeds keystrokes from the integrated TCA8418 keypad to
+     * the foreground tty — leaking keys into any shell on tty1 / HDMI
+     * console at the same time APPLaunch is reading them. EBUSY here is
+     * non-fatal: another grabber already holds it, libinput will read
+     * normally without the VT-leak protection. */
+    if (ioctl(fd, EVIOCGRAB, 1) < 0 && errno != EBUSY) {
+        fprintf(stderr, "[KBD] EVIOCGRAB %s failed: %s\n", path, strerror(errno));
+    }
+    return fd;
 }
 static void close_restricted(int fd, void *user_data) { close(fd); }
 static const struct libinput_interface interface = {


### PR DESCRIPTION
The kernel VT keyboard handler also routes events from the TCA8418 keypad (and any libinput-managed device) to the foreground tty whenever APPLaunch is reading them. Visible as duplicated input into any HDMI text console, getty or Wayland session running: keystrokes meant for the launcher's UI also land in whatever is foreground on the attached display.

Grab each fd libinput opens via the open_restricted callback. The kernel input layer then routes events only to this fd, shutting the VT handler out without affecting userspace dbus/libinput consumers. EBUSY is tolerated — libinput keeps reading, just without VT-leak protection.

Preserves the "shared with child" invariant documented in hal/linux/hal_process_linux.cpp: APPLaunch calls keyboard_pause() → libinput_suspend() before forking a child, which closes libinput's fds and releases the grab. The child opens its own ungrabbed fd alongside the ESC-hold watcher, both reading shared events as before. On child exit, libinput_resume() reopens devices and open_restricted re-grabs.

Repro on stock CZ (Raspberry Pi OS, PIXEL desktop): plug HDMI and keyboard, open a terminal window, scroll the launcher menu with the integrated keypad. The keys also land in the terminal shell.

Tested on M5Stack Cardputer Zero (CM0, factory aarch64 image).