### PR TITLE
fix: volume persist, Math path, screenshot Ctrl+Alt+S, setuid exec

### DIFF
--- a/projects/APPLaunch/main/hal/linux/hal_process_linux.cpp
+++ b/projects/APPLaunch/main/hal/linux/hal_process_linux.cpp
@@ -11,6 +11,7 @@
 #include <thread>
 #include <linux/input.h>
 #include <pwd.h>
+#include <grp.h>
 
 extern "C" {
     extern void keyboard_pause(void);
@@ -54,12 +55,19 @@ static void exec_as_user(const char *exec_path)
 {
     const char *user = get_run_user();
     if (getuid() == 0 && strcmp(user, "root") != 0) {
-        char cmd[2048];
-        snprintf(cmd, sizeof(cmd), "runuser -l %s -c '%s'", user, exec_path);
-        execlp("/bin/sh", "sh", "-c", cmd, (char *)NULL);
-    } else {
-        execlp("/bin/sh", "sh", "-c", exec_path, (char *)NULL);
+        struct passwd *pw = getpwnam(user);
+        if (pw) {
+            initgroups(pw->pw_name, pw->pw_gid);
+            setgid(pw->pw_gid);
+            setuid(pw->pw_uid);
+            setenv("HOME", pw->pw_dir, 1);
+            setenv("USER", pw->pw_name, 1);
+            setenv("LOGNAME", pw->pw_name, 1);
+            setenv("SHELL", pw->pw_shell[0] ? pw->pw_shell : "/bin/bash", 1);
+            chdir(pw->pw_dir);
+        }
     }
+    execlp("/bin/sh", "sh", "-c", exec_path, (char *)NULL);
 }
 
 /* ------------------------------------------------------------------
@@ -248,3 +256,4 @@ void hal_system_reboot(void)
     printf("[HAL] reboot\n");
     system("sudo reboot");
 }
+// rebuild trigger

--- a/projects/APPLaunch/main/hal/linux/hal_settings_linux.cpp
+++ b/projects/APPLaunch/main/hal/linux/hal_settings_linux.cpp
@@ -299,24 +299,39 @@ int hal_wifi_scan(hal_wifi_ap_t *out, int max_aps)
     while (fgets(line, sizeof(line), p) && count < max_aps) {
         line[strcspn(line, "\n")] = 0;
         if (line[0] == 0) continue;
-        hal_wifi_ap_t *ap = &out[count];
-        memset(ap, 0, sizeof(*ap));
+        hal_wifi_ap_t tmp;
+        memset(&tmp, 0, sizeof(tmp));
         char *ptr = line;
         char *last_colon = strrchr(ptr, ':');
         if (!last_colon) continue;
-        ap->in_use = (*(last_colon + 1) == '*') ? 1 : 0;
+        tmp.in_use = (*(last_colon + 1) == '*') ? 1 : 0;
         *last_colon = 0;
         char *sec_colon = strrchr(ptr, ':');
         if (!sec_colon) continue;
-        strncpy(ap->security, sec_colon + 1, sizeof(ap->security) - 1);
+        strncpy(tmp.security, sec_colon + 1, sizeof(tmp.security) - 1);
         *sec_colon = 0;
         char *sig_colon = strrchr(ptr, ':');
         if (!sig_colon) continue;
-        ap->signal = atoi(sig_colon + 1);
+        tmp.signal = atoi(sig_colon + 1);
         *sig_colon = 0;
         if (ptr[0] == 0) continue;
-        strncpy(ap->ssid, ptr, WIFI_SSID_MAX - 1);
-        count++;
+        strncpy(tmp.ssid, ptr, WIFI_SSID_MAX - 1);
+
+        /* Dedup: if same SSID already exists, keep the stronger signal */
+        int dup_idx = -1;
+        for (int i = 0; i < count; i++) {
+            if (strcmp(out[i].ssid, tmp.ssid) == 0) {
+                dup_idx = i;
+                break;
+            }
+        }
+        if (dup_idx >= 0) {
+            if (tmp.signal > out[dup_idx].signal)
+                out[dup_idx] = tmp;
+        } else {
+            out[count] = tmp;
+            count++;
+        }
     }
     pclose(p);
     return count;

--- a/projects/APPLaunch/main/src/main.cpp
+++ b/projects/APPLaunch/main/src/main.cpp
@@ -330,6 +330,13 @@ int main(void)
             hal_backlight_write(saved_bright);
     }
 
+    // Restore saved volume
+    {
+        int saved_vol = hal_config_get_int("volume", -1);
+        if (saved_vol >= 0)
+            hal_volume_write(saved_vol);
+    }
+
     ui_init();
     // lv_demo_widgets(); // 用LVGL自带demo测试
     /*Handle LVGL tasks*/

--- a/projects/APPLaunch/main/ui/components/page_app/ui_app_hack.hpp
+++ b/projects/APPLaunch/main/ui/components/page_app/ui_app_hack.hpp
@@ -103,6 +103,17 @@ private:
         return lbl;
     }
 
+    static uint32_t fzxc_to_arrow(uint32_t key)
+    {
+        switch (key) {
+        case KEY_F: return KEY_UP;
+        case KEY_X: return KEY_DOWN;
+        case KEY_Z: return KEY_LEFT;
+        case KEY_C: return KEY_RIGHT;
+        default:    return key;
+        }
+    }
+
     // ==================== keycode to char ====================
     static char keycode_to_char(uint32_t key)
     {
@@ -900,8 +911,8 @@ private:
             uint32_t key = LV_EVENT_KEYBOARD_GET_KEY(e);
             switch (view_state_)
             {
-            case ViewState::MAIN:  handle_main_key(key); break;
-            case ViewState::SUB:   handle_sub_key(key);  break;
+            case ViewState::MAIN:  handle_main_key(fzxc_to_arrow(key)); break;
+            case ViewState::SUB:   handle_sub_key(fzxc_to_arrow(key));  break;
             case ViewState::INPUT: handle_sub_key(key);  break;
             }
         }

--- a/projects/APPLaunch/main/ui/components/page_app/ui_app_setup.hpp
+++ b/projects/APPLaunch/main/ui/components/page_app/ui_app_setup.hpp
@@ -281,7 +281,7 @@ private:
                     "LVGL    : 9.x",
                     "OS Build: " __DATE__,
                     launcher_build,
-                    "Shortcut: Ctrl+S screenshot",
+                    "Shortcut: Ctrl+Alt+S screenshot",
                 };
                 for (int i = 0; i < 5; ++i) {
                     lv_obj_t *lbl = lv_label_create(c);
@@ -462,6 +462,7 @@ private:
         if (key == KEY_ENTER) {
             if (pw_hint_lbl_)
                 lv_label_set_text(pw_hint_lbl_, "Connecting...");
+            lv_refr_now(NULL);
             int ret = hal_wifi_connect(wifi_pw_ssid_.c_str(), wifi_pw_buf_.c_str());
             view_state_ = ViewState::SUB;
             lv_obj_t *content = ui_obj_.count("sub_content") ? ui_obj_["sub_content"] : nullptr;
@@ -469,8 +470,15 @@ private:
                 lv_obj_clean(content);
                 build_wifi_page(content);
             }
-            if (ret == 0)
+            if (ret == 0) {
                 wifi_refresh_status();
+            } else {
+                if (wifi_status_lbl_) {
+                    lv_label_set_text(wifi_status_lbl_, "Connection failed");
+                    lv_obj_set_style_text_color(wifi_status_lbl_,
+                        lv_color_hex(0xE74C3C), LV_PART_MAIN | LV_STATE_DEFAULT);
+                }
+            }
             return;
         }
         if (key == KEY_BACKSPACE) {
@@ -683,7 +691,7 @@ private:
     // ==================== Sound sub-page ====================
     void build_sound_page(lv_obj_t *c)
     {
-        vol_val_ = hal_volume_read();
+        vol_val_ = hal_config_get_int("volume", hal_volume_read());
         if (vol_val_ < 0) vol_val_ = 39;
         vol_muted_ = (vol_val_ == 0) ? 1 : 0;
 
@@ -691,7 +699,7 @@ private:
         vol_bar_ = make_bar(c, 0, 24, 220, 12, vol_val_, 63, 0x2ECC71);
 
         char buf[32];
-        snprintf(buf, sizeof(buf), "%d/%d", vol_val_, 63);
+        snprintf(buf, sizeof(buf), "%d%%", vol_val_ * 100 / 63);
         vol_lbl_ = make_label(c, buf, 230, 21, 0xFFFFFF);
 
         char mute_buf[32];
@@ -708,6 +716,8 @@ private:
             vol_val_ -= 3;
             if (vol_val_ < 0) vol_val_ = 0;
             hal_volume_write(vol_val_);
+            hal_config_set_int("volume", vol_val_);
+            hal_config_save();
             vol_muted_ = (vol_val_ == 0) ? 1 : 0;
             update_vol_ui();
             break;
@@ -715,6 +725,8 @@ private:
             vol_val_ += 3;
             if (vol_val_ > 63) vol_val_ = 63;
             hal_volume_write(vol_val_);
+            hal_config_set_int("volume", vol_val_);
+            hal_config_save();
             vol_muted_ = 0;
             update_vol_ui();
             break;
@@ -728,6 +740,8 @@ private:
                 vol_muted_ = 1;
             }
             hal_volume_write(vol_val_);
+            hal_config_set_int("volume", vol_val_);
+            hal_config_save();
             update_vol_ui();
             break;
         case KEY_ESC:
@@ -744,7 +758,7 @@ private:
             lv_bar_set_value(vol_bar_, vol_val_, LV_ANIM_ON);
         if (vol_lbl_) {
             char buf[32];
-            snprintf(buf, sizeof(buf), "%d/%d", vol_val_, 63);
+            snprintf(buf, sizeof(buf), "%d%%", vol_val_ * 100 / 63);
             lv_label_set_text(vol_lbl_, buf);
         }
         if (mute_lbl_) {

--- a/projects/APPLaunch/main/ui/components/ui_app_launch.cpp
+++ b/projects/APPLaunch/main/ui/components/ui_app_launch.cpp
@@ -178,7 +178,7 @@ public:
 
         app_list.emplace_back("MATH",
                               img_path("math_100.png"),
-                              "/home/pi/M5CardputerZero-Calculator-linux-aarch64", false);
+                              "/usr/share/APPLaunch/bin/M5CardputerZero-Calculator", false);
 
 #if defined(__linux__) && !defined(HAL_PLATFORM_SDL)
         app_list.emplace_back("IP_PANEL",

--- a/projects/APPLaunch/main/ui/ui_global_hint.cpp
+++ b/projects/APPLaunch/main/ui/ui_global_hint.cpp
@@ -233,9 +233,9 @@ extern "C" void ui_global_hint_on_key(const struct key_item *elm)
     /* All other keys: only fire on the initial key-down edge. */
     if (elm->key_state != KBD_KEY_PRESSED) return;
 
-    /* Ctrl+S: global screenshot */
-    if (code == KEY_S && (elm->mods & KBD_MOD_CTRL)) {
-        int ret = hal_screenshot_save("/home/pi/screenshots");
+    /* Ctrl+Alt+S: global screenshot */
+    if (code == KEY_S && (elm->mods & KBD_MOD_CTRL) && (elm->mods & KBD_MOD_ALT)) {
+        int ret = hal_screenshot_save("/var/lib/applaunch/screenshots");
         show_hint(ret == 0 ? "Screenshot saved" : "Screenshot failed");
         return;
     }


### PR DESCRIPTION
## Summary
- **Volume persistence**: save/restore across reboots, display as percentage
- **WiFi**: dedup scan results, show "Connection failed" on wrong password
- **HACK nav**: F/X/Z/C keys work as arrows without Sym
- **Math**: fix binary path to /usr/share/APPLaunch/bin/M5CardputerZero-Calculator
- **Screenshot**: change hotkey to Ctrl+Alt+S, save to /var/lib/applaunch/screenshots
- **Process exec**: use setuid/setgid directly (runuser not installed on device)

## Test plan
- [ ] Volume: set, reboot, verify persists
- [ ] Math: opens correctly
- [ ] Ctrl+Alt+S: takes screenshot
- [ ] WiFi wrong password: shows error
- [ ] HACK: F/X navigate without Sym