### PR TITLE
ui_app_setup: drop HAL_PLATFORM_SDL guard so emulator builds

### DIFF
--- a/projects/APPLaunch/main/hal/sdl/hal_filesystem_sdl.cpp
+++ b/projects/APPLaunch/main/hal/sdl/hal_filesystem_sdl.cpp
@@ -1,4 +1,5 @@
 #include "../hal_filesystem.h"
+#include <stdio.h>   // snprintf
 #include <string.h>
 #include <stdlib.h>
 

--- a/projects/APPLaunch/main/hal/sdl/hal_settings_sdl.cpp
+++ b/projects/APPLaunch/main/hal/sdl/hal_settings_sdl.cpp
@@ -53,6 +53,8 @@ int hal_wifi_connect(const char *ssid, const char *password)
     (void)ssid; (void)password; return 0;
 }
 
+int hal_wifi_disconnect(void) { return 0; }
+
 hal_bt_status_t hal_bt_get_status(void)
 {
     hal_bt_status_t st;

--- a/projects/APPLaunch/main/ui/components/page_app/ui_app_setup.hpp
+++ b/projects/APPLaunch/main/ui/components/page_app/ui_app_setup.hpp
@@ -1,5 +1,11 @@
 #pragma once
-#if !defined(HAL_PLATFORM_SDL)
+// Note: this file used to be wrapped in `#if !defined(HAL_PLATFORM_SDL)` to
+// exclude it from the emulator build, but ui_app_launch.cpp references
+// UISetupPage unconditionally. The class body is HAL-clean (uses hal_wifi_*,
+// hal_battery_*, hal_volume_*); residual raw syscalls (i2c ioctl, popen for
+// IP/whoami, sudo date) are either already inside #ifdef __linux__ or only
+// triggered by user actions that the emulator never performs. Keeping the
+// class compiled on every platform lets the emulator open the SETTING page.
 #define _STRINGIFY(x) #x
 #define STRINGIFY(x) _STRINGIFY(x)
 #ifndef LAUNCHER_GIT_COMMIT_RAW
@@ -1738,5 +1744,3 @@ public:
     UISetupPage() : app_base() { set_page_title("SETTING"); }
     ~UISetupPage() {}
 };
-
-#endif // !HAL_PLATFORM_SDL

--- a/projects/APPLaunch/main/ui/components/page_app/ui_app_setup.hpp
+++ b/projects/APPLaunch/main/ui/components/page_app/ui_app_setup.hpp
@@ -1734,13 +1734,3 @@ private:
         }
     }
 };
-
-#else // HAL_PLATFORM_SDL — stub for emulator builds
-#include "../ui_app_page.hpp"
-
-class UISetupPage : public app_base
-{
-public:
-    UISetupPage() : app_base() { set_page_title("SETTING"); }
-    ~UISetupPage() {}
-};


### PR DESCRIPTION
## Summary

Make UISetupPage compile on the emulator (macOS / SDL Linux / Web) so the SETTING page is actually reachable from APPLaunch.

## Problem

```
ui_app_launch.cpp:144:67: error: 'UISetupPage' was not declared in this scope
                              img_path("setting_100.png"), page_v<UISetupPage>);
                                                                  ^~~~~~~~~~~
```

`ui_app_setup.hpp` is currently wrapped in `#if !defined(HAL_PLATFORM_SDL)`, which excludes it from emu builds — but `ui_app_launch.cpp` registers `page_v<UISetupPage>` unconditionally, so the build is structurally broken under HAL_PLATFORM_SDL.

This breaks the [M5CardputerZero-Emulator CI](https://github.com/CardputerZero/M5CardputerZero-Emulator/actions) on every platform.

## Fix

Drop the SDL guard. The class is already HAL-clean for the parts the emu actually exercises:

- ✅ Uses HAL: `hal_wifi_*`, `hal_battery_*`, `hal_volume_*`, `hal_bt_*`, `hal_backlight_*` — all have stubs in `hal/sdl/`.
- ✅ i2c ioctl / `<linux/i2c.h>` includes — already inside `#ifdef __linux__`.
- ⚠️ Residual unguarded raw syscalls (`popen`, `system`, `/sys/class/power_supply` walk):
  - These are POSIX, compile fine on macOS/Linux hosts.
  - They're only triggered when the user navigates to specific sub-pages (Account / Ethernet / Update / Set RTC) and confirms an action — flows the emulator user can't reach without explicit input. So compiling them in isn't a runtime hazard either.
  - **Follow-up**: route them through `hal_account_info()` / `hal_eth_status()` / `hal_system_update_*()`. Out of scope for this PR.

## Test

Local macOS arm64 (with M5CardputerZero-Emulator submodule pointing at this branch):

```
$ make -C build -j10
[100%] Built target cardputer-emu
$ file build/cardputer-emu
build/cardputer-emu: Mach-O 64-bit executable arm64
$ ./build/cardputer-emu  # opens, SETTING page now reachable
```

## Companion PR

This unblocks https://github.com/CardputerZero/M5CardputerZero-Emulator/pull/2 — once this merges, that PR drops the corresponding workaround in `cmake/patches/apply_vendor_workarounds.cmake` and bumps the launcher submodule.