### PR TITLE
fix(settings): RTC 时间设置生效（新增 NTP 开关）#75

### DIFF
--- a/ext_components/cp0_lvgl/include/cp0_lvgl_app.h
+++ b/ext_components/cp0_lvgl/include/cp0_lvgl_app.h
@@ -141,6 +141,10 @@ int cp0_account_info_read(cp0_account_info_t *info);
 int cp0_system_apt_update_background(void);
 int cp0_system_update_launcher_background(void);
 int cp0_time_set(const char *timestamp);
+/* NTP auto time-sync control. get returns 1 when enabled, 0 when disabled,
+ * negative on error. Manual RTC time can only persist while NTP is disabled. */
+int cp0_time_ntp_get(void);
+int cp0_time_ntp_set(int enable);
 int cp0_bq27220_calibrate(int command_index);
 int cp0_compass_read(cp0_compass_read_cb_t callback, void *user);
 int cp0_compass_calibrate(void);

--- a/ext_components/cp0_lvgl/src/cp0/cp0_lvgl_osinfo.cpp
+++ b/ext_components/cp0_lvgl/src/cp0/cp0_lvgl_osinfo.cpp
@@ -34,6 +34,10 @@ public:
             report(callback, ret, encode_account_info(info));
         } else if (cmd == "TimeSet") {
             report(callback, time_set(nth_arg(arg, 1).c_str()), "");
+        } else if (cmd == "NtpGet") {
+            report(callback, ntp_get(), "");
+        } else if (cmd == "NtpSet") {
+            report(callback, ntp_set(nth_arg(arg, 1) == "1"), "");
         } else if (cmd == "AptUpdateBackground") {
             report(callback, apt_update_background(), "");
         } else if (cmd == "UpdateLauncherBackground") {
@@ -154,6 +158,27 @@ private:
         return cp0_process_run_argv(argv, 0);
     }
 
+    // Returns 1 if systemd automatic time sync (NTP) is enabled, 0 if disabled,
+    // negative on failure to query.
+    static int ntp_get()
+    {
+        char output[64] = {};
+        const char *argv[] = {"timedatectl", "show", "-p", "NTP", "--value", nullptr};
+        if (cp0_process_capture_argv(argv, output, sizeof(output)) != 0)
+            return -1;
+        std::string s(output);
+        // trim trailing newline / whitespace
+        while (!s.empty() && (s.back() == '\n' || s.back() == '\r' || s.back() == ' '))
+            s.pop_back();
+        return s == "yes" ? 1 : 0;
+    }
+
+    static int ntp_set(bool enable)
+    {
+        const char *argv[] = {"sudo", "timedatectl", "set-ntp", enable ? "true" : "false", nullptr};
+        return cp0_process_run_argv(argv, 0);
+    }
+
     static int apt_update_background()
     {
         const char *argv[] = {"apt", "update", nullptr};
@@ -256,6 +281,16 @@ extern "C" int cp0_account_info_read(cp0_account_info_t *info)
 extern "C" int cp0_time_set(const char *timestamp)
 {
     return OsInfoSystem::api_simple({"TimeSet", timestamp ? timestamp : ""});
+}
+
+extern "C" int cp0_time_ntp_get(void)
+{
+    return OsInfoSystem::api_simple({"NtpGet"});
+}
+
+extern "C" int cp0_time_ntp_set(int enable)
+{
+    return OsInfoSystem::api_simple({"NtpSet", enable ? "1" : "0"});
 }
 
 extern "C" int cp0_system_apt_update_background(void)

--- a/ext_components/cp0_lvgl/src/sdl/sdl_lvgl_osinfo.cpp
+++ b/ext_components/cp0_lvgl/src/sdl/sdl_lvgl_osinfo.cpp
@@ -74,6 +74,10 @@ public:
             report(callback, ret, encode_account_info(info));
         } else if (cmd == "TimeSet") {
             report(callback, time_set(nth_arg(arg, 1).c_str()), "");
+        } else if (cmd == "NtpGet") {
+            report(callback, 0, ""); // emulator: NTP considered off so manual set is allowed
+        } else if (cmd == "NtpSet") {
+            report(callback, 0, ""); // emulator: no-op
         } else if (cmd == "AptUpdateBackground") {
             report(callback, apt_update_background(), "");
         } else if (cmd == "UpdateLauncherBackground") {
@@ -328,6 +332,16 @@ extern "C" int cp0_account_info_read(cp0_account_info_t *info)
 extern "C" int cp0_time_set(const char *timestamp)
 {
     return SdlOsInfoSystem::api_simple({"TimeSet", timestamp ? timestamp : ""});
+}
+
+extern "C" int cp0_time_ntp_get(void)
+{
+    return SdlOsInfoSystem::api_simple({"NtpGet"});
+}
+
+extern "C" int cp0_time_ntp_set(int enable)
+{
+    return SdlOsInfoSystem::api_simple({"NtpSet", enable ? "1" : "0"});
 }
 
 extern "C" int cp0_system_apt_update_background(void)

--- a/projects/APPLaunch/main/ui/page_app/ui_app_setup.hpp
+++ b/projects/APPLaunch/main/ui/page_app/ui_app_setup.hpp
@@ -301,6 +301,7 @@ private:
             MenuItem m;
             m.label = "RTC";
             m.sub_items = {
+                {"NTP",    true,  true,  [this]() { ntp_toggle(); }},
                 {"Year",   false, false, [this]() { enter_rtc_adjust(0); }},
                 {"Month",  false, false, [this]() { enter_rtc_adjust(1); }},
                 {"Day",    false, false, [this]() { enter_rtc_adjust(2); }},
@@ -590,9 +591,11 @@ private:
     // ==================== RTC ====================
     int rtc_values_[6] = {2026, 1, 1, 0, 0, 0}; // Y/M/D/H/Min/S
     int rtc_field_ = 0;
+    bool rtc_ntp_on_ = true; // cached NTP state; manual set only allowed when off
 
     void refresh_rtc_values()
     {
+        rtc_ntp_on_ = cp0_time_ntp_get() == 1;
         time_t now = time(NULL);
         struct tm *t = localtime(&now);
         if (t) {
@@ -603,21 +606,36 @@ private:
             rtc_values_[4] = t->tm_min;
             rtc_values_[5] = t->tm_sec;
         }
-        // Update labels
+        // Update labels. sub_items[0] is the NTP toggle; date fields follow.
         for (auto &m : menu_items_) {
             if (m.label != "RTC") continue;
+            m.sub_items[0].toggle_state = rtc_ntp_on_;
             char buf[32];
             const char *names[] = {"Year", "Month", "Day", "Hour", "Minute", "Second"};
             for (int i = 0; i < 6; ++i) {
                 snprintf(buf, sizeof(buf), "%s: %d", names[i], rtc_values_[i]);
-                m.sub_items[i].label = buf;
+                m.sub_items[i + 1].label = buf;
             }
             break;
         }
     }
 
+    void ntp_toggle()
+    {
+        for (auto &m : menu_items_) {
+            if (m.label != "RTC") continue;
+            bool on = m.sub_items[0].toggle_state; // already flipped by handler
+            cp0_time_ntp_set(on ? 1 : 0);
+            break;
+        }
+        refresh_rtc_values();
+    }
+
     void enter_rtc_adjust(int field)
     {
+        // Manual time can only persist while NTP auto-sync is off.
+        if (rtc_ntp_on_)
+            return;
         rtc_field_ = field;
         const char *names[] = {"Year", "Month", "Day", "Hour", "Minute", "Second"};
         val_title_ = names[field];
@@ -648,6 +666,7 @@ private:
                  rtc_values_[0], rtc_values_[1], rtc_values_[2],
                  rtc_values_[3], rtc_values_[4], rtc_values_[5]);
         cp0_time_set(timestamp);
+        refresh_rtc_values();
     }
 
     void save_app_toggle(const std::string &config_key)
@@ -1222,6 +1241,11 @@ private:
     // hostname, version, ...) scroll instead of overflowing or overlapping. (#57)
     static constexpr int VALUE_BOX_LEFT = 112;
     static constexpr int VALUE_BOX_W    = 100; // 超过 100px 即缩宽并滚动
+    // Right-column hint (ok:xxx) scroll threshold. The hint sits at the far right,
+    // to the right of any toggle indicator (x=220). Anything wider than this is
+    // clamped into a right-edge box and marquee-scrolled. Slightly smaller than the
+    // center VALUE_BOX_W so it clears the toggle indicator instead of overlapping it.
+    static constexpr int RIGHT_HINT_BOX_W = 74;
 
     RowStyle style_for_slot(int vi) {
         int dist = vi > ROW_CENTER ? vi - ROW_CENTER : ROW_CENTER - vi;
@@ -1582,16 +1606,35 @@ private:
         // Hint for selected sub item (right-aligned, 6px from right edge, smaller font)
         SubItem &cur_sub = item.sub_items[sub_selected_idx_];
         lv_obj_t *hint = lv_label_create(cont);
-        if (cur_sub.is_toggle)
+        if (cur_sub.is_toggle && item.label == "RTC" && cur_sub.label == "NTP")
+            lv_label_set_text(hint, cur_sub.toggle_state ? "ok:disable" : "ok:enable");
+        else if (cur_sub.is_toggle)
             lv_label_set_text(hint, cur_sub.toggle_state ? "ok:hide" : "ok:select");
+        else if (item.label == "RTC" && rtc_ntp_on_)
+            lv_label_set_text(hint, "ntp on");
         else
             lv_label_set_text(hint, "ok:enter");
         lv_obj_set_style_text_color(hint, lv_color_hex(0x00CC66), LV_PART_MAIN);
         lv_obj_set_style_text_font(hint, launcher_fonts().get("Montserrat-Bold.ttf", 16, LV_FREETYPE_FONT_STYLE_BOLD), LV_PART_MAIN);
+        apply_right_hint_overflow(hint, row_y(sub_center_vi));
+    }
+
+    // Position the far-right hint (ok:xxx). If it is wider than RIGHT_HINT_BOX_W it is
+    // clamped into a right-edge box and marquee-scrolled (so long hints like "ok:disable"
+    // don't overlap the toggle indicator); otherwise it keeps its natural right-aligned pos.
+    void apply_right_hint_overflow(lv_obj_t *hint, int row_top_y)
+    {
         lv_obj_update_layout(hint);
-        int sub_hint_w = lv_obj_get_width(hint);
-        int sub_hint_h = lv_obj_get_height(hint);
-        lv_obj_set_pos(hint, SCREEN_W - 6 - sub_hint_w, row_y(sub_center_vi) + (row_h() - sub_hint_h) / 2);
+        int hw = lv_obj_get_width(hint);
+        int hh = lv_obj_get_height(hint);
+        int y = row_top_y + (row_h() - hh) / 2;
+        if (hw > RIGHT_HINT_BOX_W) {
+            lv_obj_set_width(hint, RIGHT_HINT_BOX_W);
+            lv_obj_set_pos(hint, SCREEN_W - 6 - RIGHT_HINT_BOX_W, y);
+            lv_label_set_long_mode(hint, LV_LABEL_LONG_SCROLL_CIRCULAR);
+        } else {
+            lv_obj_set_pos(hint, SCREEN_W - 6 - hw, y);
+        }
     }
 
     // ==================== Value select view (3rd level) ====================


### PR DESCRIPTION
## Summary
修复 Settings → RTC 中修改年月日时分秒无效的问题（#75）。

**根因**：手动 `date -s` 其实执行成功了，但 `systemd-timesyncd`(NTP) 一直在后台同步，会立刻把手动设置的时间覆盖回网络时间，所以看起来"设置无效"。

**方案**：在 RTC 子菜单顶部新增 **NTP 开关**，只有关闭 NTP 后才允许手动设置时间。
- 新增后端 `cp0_time_ntp_get/set`（`timedatectl show -p NTP` 读、`sudo timedatectl set-ntp` 写），device(cp0) 与 emulator(sdl) 两路都实现。
- RTC 菜单第一项为 NTP toggle；NTP 开启时年月日等为只读、提示 `ntp on`，关闭后才可进入设置。
- 设置成功后立即刷新菜单显示值。
- NTP 开关提示文案用 `ok:disable` / `ok:enable`（替代通用的 `ok:hide` / `ok:select`）。
- 右边栏提示超过 `RIGHT_HINT_BOX_W` 阈值时跑马灯滚动，避免长提示（`ok:disable`）与开关指示图标重叠。

## 改动文件
- `ext_components/cp0_lvgl/include/cp0_lvgl_app.h`
- `ext_components/cp0_lvgl/src/cp0/cp0_lvgl_osinfo.cpp`
- `ext_components/cp0_lvgl/src/sdl/sdl_lvgl_osinfo.cpp`
- `projects/APPLaunch/main/ui/page_app/ui_app_setup.hpp`

## Test plan
- [x] Docker(arm64) 编译通过
- [x] 部署真机 192.168.50.150：确认手动 `set-ntp false` + `date -s` 后时间不再被 NTP 改回
- [ ] 真机 UI：RTC → 关 NTP → 改 Year/Month/... → 退出再进确认保持；再开 NTP 自动校回
- [ ] 长提示 `ok:disable` 跑马灯滚动、不与指示图标重叠

Made with [Cursor](https://cursor.com)