### PR TITLE
fix(settings): never persist wrong wifi password, re-prompt until success (#69)

### DIFF
--- a/ext_components/cp0_lvgl/src/cp0/cp0_lvgl_network.cpp
+++ b/ext_components/cp0_lvgl/src/cp0/cp0_lvgl_network.cpp
@@ -173,20 +173,33 @@ public:
         if (!ssid || !ssid[0])
             return -1;
 
+        const bool with_password = password && password[0];
         char output[4096] = {};
-        int ret = -1;
-        if (password && password[0]) {
+        if (with_password) {
             const char *argv[] = {"nmcli", "dev", "wifi", "connect", ssid, "password", password, nullptr};
-            ret = cp0_process_capture_argv(argv, output, sizeof(output));
+            cp0_process_capture_argv(argv, output, sizeof(output));
         } else {
             const char *argv[] = {"nmcli", "con", "up", "id", ssid, nullptr};
-            ret = cp0_process_capture_argv(argv, output, sizeof(output));
+            cp0_process_capture_argv(argv, output, sizeof(output));
         }
 
-        if (ret == 0 || std::string(output).find("successfully") != std::string::npos) {
+        // Success is determined by NetworkManager's explicit activation message
+        // ("... successfully activated ..."), NOT by the nmcli exit code: on a wrong
+        // password nmcli sometimes still exits 0, which would make us treat a failed
+        // attempt as connected and leave the bad-password profile behind.
+        if (std::string(output).find("successfully activated") != std::string::npos) {
             update_status_cache();
             return 0;
         }
+
+        // Failed. When the user just entered a password, nmcli may have saved a
+        // profile with that wrong password (named after the SSID). Delete it so the
+        // password is never persisted and the next attempt must re-enter it (#69).
+        if (with_password) {
+            const char *del_argv[] = {"nmcli", "con", "delete", "id", ssid, nullptr};
+            cp0_process_run_argv(del_argv, 0);
+        }
+        update_status_cache();
         return -1;
     }
 

--- a/projects/APPLaunch/main/ui/page_app/ui_app_setup.hpp
+++ b/projects/APPLaunch/main/ui/page_app/ui_app_setup.hpp
@@ -910,6 +910,15 @@ private:
         } else if (wifi_has_saved_profile(ap->ssid)) {
             wifi_show_connecting(ap->ssid);
             ret = launcher_wifi::connect(ap->ssid, NULL);
+            if (ret != 0) {
+                // Saved profile failed to connect (e.g. stale/wrong password). Fall
+                // back to asking for the password again instead of silently erroring,
+                // so the user can re-enter it until the connection succeeds (#69).
+                needs_password = true;
+                wifi_pw_ssid_ = ap->ssid;
+                wifi_pw_buf_.clear();
+                show_wifi_pw_input();
+            }
         } else {
             needs_password = true;
             wifi_pw_ssid_ = ap->ssid;


### PR DESCRIPTION
## 背景 (#69)
进入 Settings → WiFi，选某个 WiFi 输入**错误密码**连接失败后，**二次选择该 WiFi 直接尝试连接并报错，不再让用户重新输入密码**。期望：连接失败时不应保存密码，状态也不应是"密码已写入"，必须重新输入密码直到连接成功。

## 根因
- 设备上 `nmcli dev wifi connect <ssid> password <pw>` 即使密码错误也会留下一个名为 `<ssid>` 的 profile。
- 后端 `connect()` 用 `ret == 0 || 含 "successfully"` 判定成功，但 nmcli 在认证失败时 **exit code 有时仍为 0**，于是失败被当成成功，错密码 profile 残留。
- 二次选择该 WiFi 时 `wifi_has_saved_profile` 命中 → 直接用错密码 `con up` → 直接报错，且不再弹出密码输入框。

## 修复
- **`cp0_lvgl_network.cpp` `connect()`**：
  - 成功判定严格匹配 NetworkManager 的 `"successfully activated"` 消息，不再信任 nmcli exit code。
  - 带密码连接**失败时主动 `nmcli con delete id <ssid>`**，确保错密码永不落盘，下次必须重新输入。
- **`ui_app_setup.hpp` `wifi_try_connect()`**：
  - 已保存 profile 直连失败时**回退到重新弹出密码输入框**，而非静默报错；即使修复前已残留的错密码 profile 也能让用户重新输入恢复，直到连上为止。

## 测试
- 真机 192.168.50.150 已部署验证：
  - 输错密码 → 连接失败 → 再次选择同一 WiFi → **重新弹出密码输入框**，输入正确密码可连上。
  - 已连过的网络下次选择仍能用已保存 profile 正常直连。

Made with [Cursor](https://cursor.com)