### PR TITLE
fix(emulator): add cp0_time_ntp HAL stubs for web/windows builds

### DIFF
--- a/projects/CardputerZero-Emulator/src/cp0_web_runtime.cpp
+++ b/projects/CardputerZero-Emulator/src/cp0_web_runtime.cpp
@@ -599,6 +599,8 @@ int cp0_account_info_read(cp0_account_info_t *info)
 int cp0_system_apt_update_background(void) { return -1; }
 int cp0_system_update_launcher_background(void) { return -1; }
 int cp0_time_set(const char *) { return -1; }
+int cp0_time_ntp_get(void) { return 0; }
+int cp0_time_ntp_set(int) { return -1; }
 int cp0_bq27220_calibrate(int) { return -1; }
 int cp0_compass_calibrate(void) { return -1; }
 int cp0_compass_read(cp0_compass_read_cb_t callback, void *user)


### PR DESCRIPTION
## Problem
The **web** and **windows** emulator jobs of *Build Emulator* fail at link with:

```
undefined reference to `cp0_time_ntp_get'
undefined reference to `cp0_time_ntp_set'
```

(see run [27974832265](https://github.com/CardputerZero/launcher/actions/runs/27974832265))

PR #75 (`fix(settings): make RTC time setting work via NTP toggle`) added
`cp0_time_ntp_get()` / `cp0_time_ntp_set()` calls in `ui_app_setup.hpp`.

- **Linux** links `CP0_LVGL_SDL_SRCS` (`sdl/sdl_lvgl_osinfo.cpp`) which implements them → OK
- **macOS** links APPLaunch as a shared lib with `-undefined dynamic_lookup` → tolerated
- **web (Emscripten)** and **windows (MinGW)** link `src/cp0_web_runtime.cpp` + HAL stubs *without* the SDL sources, and link statically → **undefined symbol**

## Fix
Add the two missing symbols as HAL stubs in `cp0_web_runtime.cpp` (the runtime
shared by both the web and win32 emulator targets), next to the existing
`cp0_time_set` / `cp0_time_str` stubs:

- `cp0_time_ntp_get()` → returns `0` (NTP reported off; caller checks `== 1`)
- `cp0_time_ntp_set(int)` → no-op

## Test plan
- [ ] *Build Emulator* web job links and packages
- [ ] *Build Emulator* windows job links and packages
- [x] linux / macOS jobs unaffected (no source change to their paths)

Made with [Cursor](https://cursor.com)