### PR TITLE
feat(settings): implement DarkTime idle screen blanking in launcher (#72)

### DIFF
--- a/ext_components/cp0_lvgl/src/cp0/cp0_lvgl_keyboard.c
+++ b/ext_components/cp0_lvgl/src/cp0/cp0_lvgl_keyboard.c
@@ -106,6 +106,15 @@ __attribute__((weak)) void ui_global_hint_on_key(const struct key_item *elm)
     (void)elm;
 }
 
+/* Optional idle screen-blanking ("DarkTime") hook, provided by the launcher.
+ * Returns 1 if the key was swallowed only to wake the screen and must not be
+ * delivered to the UI. Weak no-op for apps that don't implement it. */
+__attribute__((weak)) int ui_darkscreen_filter_key(const struct key_item *elm)
+{
+    (void)elm;
+    return 0;
+}
+
 static const char *getenv_default(const char *name, const char *dflt)
 {
     const char *value = getenv(name);
@@ -172,15 +181,23 @@ static void cp0_keypad_read_cb(lv_indev_t *indev, lv_indev_data_t *data)
                elm->key_code, kbd_state_name(elm->key_state), elm->sym_name,
                utf8_dbg, elm->codepoint, (void *)lv_screen_active());
 
-        lv_obj_t *root = lv_screen_active();
-        if (root)
-            lv_obj_send_event(root, (lv_event_code_t)LV_EVENT_KEYBOARD, elm);
+        /* DarkTime: if the screen is blanked this key only wakes it and must
+         * not reach the UI (nor the keypad indev) so it doesn't also act. */
+        int swallowed = ui_darkscreen_filter_key(elm);
 
-        ui_global_hint_on_key(elm);
+        if (!swallowed) {
+            lv_obj_t *root = lv_screen_active();
+            if (root)
+                lv_obj_send_event(root, (lv_event_code_t)LV_EVENT_KEYBOARD, elm);
 
-        data->key = cp0_evdev_process_key(elm->key_code);
-        if (data->key) {
-            data->state = (lv_indev_state_t)elm->key_state;
+            ui_global_hint_on_key(elm);
+
+            data->key = cp0_evdev_process_key(elm->key_code);
+            if (data->key) {
+                data->state = (lv_indev_state_t)elm->key_state;
+                data->continue_reading = !STAILQ_EMPTY(&keyboard_queue);
+            }
+        } else {
             data->continue_reading = !STAILQ_EMPTY(&keyboard_queue);
         }
         free(elm);

--- a/ext_components/cp0_lvgl/src/sdl/sdl_lvgl_keyboard.c
+++ b/ext_components/cp0_lvgl/src/sdl/sdl_lvgl_keyboard.c
@@ -26,6 +26,12 @@ typedef struct {
 static void cp0_sdl_keyboard_read(lv_indev_t *indev, lv_indev_data_t *data);
 static void cp0_sdl_keyboard_delete_cb(lv_event_t *event);
 
+__attribute__((weak)) int ui_darkscreen_filter_key(const struct key_item *elm)
+{
+    (void)elm;
+    return 0;
+}
+
 __attribute__((weak)) void ui_global_hint_on_key(const struct key_item *elm)
 {
     (void)elm;
@@ -513,15 +519,21 @@ static void cp0_sdl_keyboard_read(lv_indev_t *indev, lv_indev_data_t *data)
         struct key_item *elm = STAILQ_FIRST(&keyboard_queue);
         STAILQ_REMOVE_HEAD(&keyboard_queue, entries);
 
-        lv_obj_t *root = lv_screen_active();
-        if (root != NULL)
-            lv_obj_send_event(root, (lv_event_code_t)LV_EVENT_KEYBOARD, elm);
+        int swallowed = ui_darkscreen_filter_key(elm);
 
-        ui_global_hint_on_key(elm);
+        if (!swallowed) {
+            lv_obj_t *root = lv_screen_active();
+            if (root != NULL)
+                lv_obj_send_event(root, (lv_event_code_t)LV_EVENT_KEYBOARD, elm);
 
-        data->key = cp0_evdev_process_key(elm->key_code);
-        if (data->key) {
-            data->state = (lv_indev_state_t)elm->key_state;
+            ui_global_hint_on_key(elm);
+
+            data->key = cp0_evdev_process_key(elm->key_code);
+            if (data->key) {
+                data->state = (lv_indev_state_t)elm->key_state;
+                data->continue_reading = !STAILQ_EMPTY(&keyboard_queue);
+            }
+        } else {
             data->continue_reading = !STAILQ_EMPTY(&keyboard_queue);
         }
         free(elm);

--- a/projects/APPLaunch/main/src/main.cpp
+++ b/projects/APPLaunch/main/src/main.cpp
@@ -11,6 +11,7 @@
 #include <chrono>
 #include <string>
 #include "ui/ui.h"
+#include "ui/ui_darkscreen.h"
 #include "keyboard_input.h"
 #include "cp0_lvgl_app.h"
 #include "cp0_lvgl_file.hpp"
@@ -86,6 +87,7 @@ int main(void)
     SLOGI("Entering main loop (FULL render mode)...");
     while(1) {
         APPLaunch_lock();
+        ui_darkscreen_tick();
         lv_timer_handler();
         usleep(5000);
     }

--- a/projects/APPLaunch/main/ui/page_app/ui_app_setup.hpp
+++ b/projects/APPLaunch/main/ui/page_app/ui_app_setup.hpp
@@ -375,7 +375,12 @@ private:
     {
         val_title_ = "DarkTime";
         val_options_ = {"Never", "10S", "30S", "60S", "300S"};
-        val_sel_idx_ = 2; // default 30S
+        const int times[] = {0, 10, 30, 60, 300};
+        int saved = config_get_int("dark_time", 30); // default 30S
+        val_sel_idx_ = 2;
+        for (int i = 0; i < (int)(sizeof(times) / sizeof(times[0])); ++i) {
+            if (times[i] == saved) { val_sel_idx_ = i; break; }
+        }
         view_state_ = ViewState::VALUE_SELECT;
         transition_enter_level();
     }
@@ -1168,7 +1173,8 @@ private:
         } else if (val_title_ == "Volume") {
             apply_volume();
         } else if (val_title_ == "DarkTime") {
-            // TODO: save dark time setting
+            // Idle screen-blank timeout in seconds (0 = Never); consumed by
+            // ui_darkscreen_tick() in the launcher main loop (#72).
             int times[] = {0, 10, 30, 60, 300};
             config_set_int("dark_time", times[val_sel_idx_]);
             config_save();

--- a/projects/APPLaunch/main/ui/ui_darkscreen.cpp
+++ b/projects/APPLaunch/main/ui/ui_darkscreen.cpp
@@ -1,0 +1,169 @@
+/*
+ * SPDX-FileCopyrightText: 2026 M5Stack Technology CO LTD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * ui_darkscreen.cpp — see ui_darkscreen.h for the feature description (#72).
+ */
+
+#include "ui_darkscreen.h"
+
+#include "lvgl/lvgl.h"
+#include "keyboard_input.h"
+#include "cp0_lvgl_app.h"
+#include "hal_lvgl_bsp.h"
+
+#include <string>
+
+/* Cached state ----------------------------------------------------------- */
+static uint32_t  s_last_activity_tick = 0;   /* lv_tick_get() of last key */
+static bool      s_dark              = false; /* screen currently blanked */
+static int       s_saved_backlight   = -1;    /* brightness before blanking */
+static lv_obj_t *s_black             = nullptr;
+
+/* The key that woke the screen is swallowed (press + repeats + its release)
+ * so it does not also trigger a UI action. */
+static uint32_t  s_swallow_code   = 0;
+static bool      s_swallow_active = false;
+
+/* Tracks LVGL_RUN_FLAGE edges so we can reset the idle timer when the
+ * launcher regains the foreground after a sub-app exits. */
+static int       s_prev_run = 1;
+
+static int config_get_int(const char *key, int default_val)
+{
+    int val = default_val;
+    cp0_signal_config_api({"GetInt", key ? std::string(key) : std::string(), std::to_string(default_val)},
+                          [&](int code, std::string data) {
+                              if (code == 0) val = std::atoi(data.c_str());
+                          });
+    return val;
+}
+
+/* Configured idle timeout in seconds (0 = Never). Defaults to 30s. */
+static int darkscreen_timeout_secs()
+{
+    return config_get_int("dark_time", 30);
+}
+
+static void ensure_black_overlay()
+{
+    if (s_black != nullptr) return;
+    lv_obj_t *parent = lv_layer_top();
+    if (parent == nullptr) return;
+
+    s_black = lv_obj_create(parent);
+    lv_obj_remove_style_all(s_black);
+
+    lv_display_t *disp = lv_display_get_default();
+    int w = disp ? lv_display_get_horizontal_resolution(disp) : 320;
+    int h = disp ? lv_display_get_vertical_resolution(disp) : 170;
+    lv_obj_set_size(s_black, w, h);
+    lv_obj_set_pos(s_black, 0, 0);
+
+    lv_obj_set_style_bg_color(s_black, lv_color_black(), 0);
+    lv_obj_set_style_bg_opa(s_black, LV_OPA_COVER, 0);
+    lv_obj_set_style_border_width(s_black, 0, 0);
+    lv_obj_set_style_radius(s_black, 0, 0);
+    lv_obj_set_style_pad_all(s_black, 0, 0);
+
+    lv_obj_clear_flag(s_black, LV_OBJ_FLAG_CLICKABLE);
+    lv_obj_clear_flag(s_black, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_flag(s_black, LV_OBJ_FLAG_IGNORE_LAYOUT);
+    lv_obj_add_flag(s_black, LV_OBJ_FLAG_HIDDEN);
+}
+
+static void darkscreen_go_dark()
+{
+    if (s_dark) return;
+
+    s_saved_backlight = cp0_backlight_read();
+    if (s_saved_backlight <= 0)
+        s_saved_backlight = config_get_int("brightness", -1);
+    if (s_saved_backlight <= 0)
+        s_saved_backlight = cp0_backlight_max();
+
+    ensure_black_overlay();
+    if (s_black) {
+        lv_obj_move_foreground(s_black);
+        lv_obj_clear_flag(s_black, LV_OBJ_FLAG_HIDDEN);
+    }
+    /* Paint the black frame before cutting the backlight so no stale UI flashes. */
+    lv_refr_now(NULL);
+    cp0_backlight_write(0);
+    s_dark = true;
+}
+
+static void darkscreen_wake()
+{
+    if (!s_dark) return;
+
+    int b = s_saved_backlight;
+    if (b <= 0) b = config_get_int("brightness", -1);
+    if (b <= 0) b = cp0_backlight_max();
+    if (b <= 0) b = 50;
+    cp0_backlight_write(b);
+
+    if (s_black)
+        lv_obj_add_flag(s_black, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_invalidate(lv_screen_active());
+
+    s_dark = false;
+    s_last_activity_tick = lv_tick_get();
+}
+
+extern "C" int ui_darkscreen_filter_key(const struct key_item *elm)
+{
+    if (elm == nullptr) return 0;
+
+    s_last_activity_tick = lv_tick_get();
+
+    /* Mid-swallow: keep eating the waking key's events until it is released. */
+    if (s_swallow_active) {
+        if (elm->key_code == s_swallow_code) {
+            if (elm->key_state == KBD_KEY_RELEASED)
+                s_swallow_active = false;
+            return 1;
+        }
+        s_swallow_active = false; /* a different key: stop swallowing */
+    }
+
+    if (s_dark) {
+        darkscreen_wake();
+        s_swallow_code   = elm->key_code;
+        s_swallow_active = (elm->key_state != KBD_KEY_RELEASED);
+        return 1;
+    }
+    return 0;
+}
+
+extern "C" void ui_darkscreen_tick(void)
+{
+    int run = LVGL_RUN_FLAGE;
+
+    /* Just regained the foreground (a sub-app exited): restart the idle clock
+     * so we don't immediately blank, and drop any pending swallow state. */
+    if (run == 1 && s_prev_run != 1) {
+        s_last_activity_tick = lv_tick_get();
+        s_swallow_active = false;
+    }
+    s_prev_run = run;
+
+    /* Only the foreground launcher blanks; leave sub-apps untouched. */
+    if (run != 1) return;
+
+    int secs = darkscreen_timeout_secs();
+    if (secs <= 0) {            /* Never */
+        if (s_dark) darkscreen_wake();
+        return;
+    }
+    if (s_dark) return;
+
+    if (s_last_activity_tick == 0)
+        s_last_activity_tick = lv_tick_get();
+
+    if (lv_tick_elaps(s_last_activity_tick) >= (uint32_t)secs * 1000u)
+        darkscreen_go_dark();
+}

--- a/projects/APPLaunch/main/ui/ui_darkscreen.h
+++ b/projects/APPLaunch/main/ui/ui_darkscreen.h
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: 2026 M5Stack Technology CO LTD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * ui_darkscreen.h
+ *
+ * "DarkTime" idle screen blanking for the launcher (#72).
+ *
+ * After the configured idle timeout ("dark_time" seconds, 0 = Never) with no
+ * key activity, the launcher turns the backlight off AND paints a full-screen
+ * black overlay so the panel is fully dark. Any key press wakes it again; that
+ * waking key is swallowed so it does not also trigger an action.
+ *
+ * Only active while the launcher is the foreground process
+ * (LVGL_RUN_FLAGE == 1); sub-apps are unaffected.
+ */
+
+#ifndef UI_DARKSCREEN_H
+#define UI_DARKSCREEN_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct key_item;
+
+/* Call once per main-loop iteration. Blanks the screen after the configured
+ * idle timeout while the launcher is in the foreground. */
+void ui_darkscreen_tick(void);
+
+/* Per-key hook, invoked from the central keyboard dispatch BEFORE the key is
+ * delivered to the UI. Resets the idle timer on every key. Returns 1 if the
+ * key was swallowed (used only to wake the screen) and must NOT reach the UI;
+ * returns 0 otherwise. */
+int ui_darkscreen_filter_key(const struct key_item *elm);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UI_DARKSCREEN_H */


### PR DESCRIPTION
## 背景 (#72)
Setting 中的 **DarkTime 不可用** —— 之前只把配置 `dark_time` 存下来，没有任何实际熄屏逻辑（代码里是 TODO）。

需求：DarkTime = 熄屏（背光关 + 屏幕刷黑），直到任意按键唤醒，**仅在 launcher 生效**。

## 实现
- 新增 `ui_darkscreen` 模块：
  - `ui_darkscreen_tick()`（主循环每帧调用）：空闲超过 `dark_time` 秒（默认 30，0=Never）无按键 → 全屏黑色遮罩 + 关背光；
  - `ui_darkscreen_filter_key()`：每个按键重置空闲计时；熄屏时该键**仅用于唤醒并被吞掉**（连同其 release），不会触发任何动作。
- 中心键盘分发（cp0 + sdl）在把按键派发给 UI 前调用新的 weak 钩子：
  - 仅 launcher 提供强实现，子 App 用 weak 空实现 → **天然只在 launcher 生效**；
  - 子 App 持屏时（`LVGL_RUN_FLAGE != 1`）不熄屏。
- Settings 的 DarkTime 菜单现在会**回显已保存的值**（之前固定显示 30S）。

## 测试
- 真机 192.168.110.135 验证：空闲到时后屏幕刷成全黑（遮罩生效），按任意键立即唤醒且不误触发动作；菜单可正确设置/回显。
- 备注：该机型 `m5stack,pwm-backlight` 的 `brightness` 节点不驱动物理背光，所以物理背光辉光无法通过 `brightness` 关闭；熄屏以黑色遮罩为主，背光关闭按现有 `cp0_backlight_write` 接口尝试（在该机上为空操作，不影响功能）。

Made with [Cursor](https://cursor.com)