### PR TITLE
fix(LaunchWizard): use FULL fbdev render mode to fix black first frame

### DIFF
--- a/projects/LaunchWizard/linux_x86_cross_cp0_config_defaults.mk
+++ b/projects/LaunchWizard/linux_x86_cross_cp0_config_defaults.mk
@@ -24,6 +24,10 @@ CONFIG_V9_5_LV_FONT_MONTSERRAT_22=y
 CONFIG_V9_5_LV_FONT_DEFAULT_MONTSERRAT_14=y
 
 CONFIG_V9_5_LV_USE_LINUX_FBDEV=y
+# FULL render mode: render the whole frame into the buffer, then write it to
+# fb0 in one shot. PARTIAL mode leaves the first frame black until a user event
+# (and causes SPI tearing). Mirrors APPLaunch's fix.
+CONFIG_V9_5_LV_LINUX_FBDEV_RENDER_MODE_FULL=y
 CONFIG_V9_5_LV_DRAW_SW_ASM_NEON=y
 CONFIG_V9_5_LV_USE_DRAW_SW_ASM=1
 CONFIG_V9_5_LV_USE_EVDEV=y


### PR DESCRIPTION
## Summary
- LaunchWizard built in LVGL **PARTIAL** fbdev render mode, so the OOBE's first frame stayed black until a key press triggered a redraw (and the SPI LCD tore). Enable `CONFIG_V9_5_LV_LINUX_FBDEV_RENDER_MODE_FULL` for the CardputerZero cross build, mirroring APPLaunch's earlier fix (`08bddc4`): render the whole frame into the buffer, then write it to fb0 in one shot.
- Needed by the new bundled-into-APPLaunch flow too — the CI-built `/usr/share/APPLaunch/bin/LaunchWizard` inherits this config.

## Verification
- Built on device; captured `/dev/fb0`: before = black (only a cursor), after = the "First Setup" welcome screen renders immediately at boot with no keypress.

## Test plan
- [ ] Trigger the OOBE on a device → welcome screen draws on the first frame, no key press required, no tearing.

Made with [Cursor](https://cursor.com)