### PR TITLE
fix: stabilize CardputerZero audio and startup lifecycle

### DIFF
--- a/ext_components/cp0_lvgl/src/cp0/cp0_audio_system_sound_player.cpp
+++ b/ext_components/cp0_lvgl/src/cp0/cp0_audio_system_sound_player.cpp
@@ -5,7 +5,11 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <mutex>
+#include <thread>
 
 class Cp0SystemSoundPlayer::Impl
 {
@@ -14,17 +18,54 @@ public:
 
     Impl()
         : names{"Ding2.wav", "key_back.wav", "key_back.wav"}
+        , cleanup_thread(&Impl::cleanup_loop, this)
     {
-        load();
     }
 
     ~Impl()
     {
+        cleanup_stop.store(true);
+        cleanup_cv.notify_one();
+        if (cleanup_thread.joinable())
+            cleanup_thread.join();
+
         std::lock_guard<std::mutex> lock(mutex);
         unload();
-        if (initialized) {
-            ma_engine_uninit(&engine);
-            ma_context_uninit(&context);
+        uninitialize();
+    }
+
+    static void sound_end_callback(void *user_data, ma_sound *)
+    {
+        auto *self = static_cast<Impl *>(user_data);
+        self->cleanup_requested.store(true);
+        self->cleanup_cv.notify_one();
+    }
+
+    void cleanup_loop()
+    {
+        std::unique_lock<std::mutex> wait_lock(cleanup_wait_mutex);
+        while (!cleanup_stop.load()) {
+            cleanup_cv.wait(wait_lock, [this] {
+                return cleanup_stop.load() || cleanup_requested.load();
+            });
+            if (cleanup_stop.load())
+                break;
+
+            cleanup_requested.store(false);
+            wait_lock.unlock();
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+            {
+                std::lock_guard<std::mutex> lock(mutex);
+                bool playing = false;
+                for (std::size_t i = 0; i < slots.size(); ++i)
+                    playing = playing ||
+                              (slots[i] && ma_sound_is_playing(&sounds[i]));
+                if (!playing) {
+                    unload();
+                    uninitialize();
+                }
+            }
+            wait_lock.lock();
         }
     }
 
@@ -61,11 +102,17 @@ public:
             if (path.empty())
                 continue;
             if (ma_sound_init_from_file(&engine, path.c_str(), MA_SOUND_FLAG_DECODE,
-                                        nullptr, nullptr, &sounds[i]) == MA_SUCCESS)
+                                        nullptr, nullptr, &sounds[i]) == MA_SUCCESS) {
+                ma_sound_set_end_callback(&sounds[i], sound_end_callback, this);
                 slots[i] = true;
+            }
         }
         loaded = std::any_of(slots.begin(), slots.end(), [](bool slot) { return slot; });
-        return loaded ? 0 : -3;
+        if (loaded)
+            return 0;
+
+        uninitialize();
+        return -3;
     }
 
     void unload()
@@ -77,6 +124,15 @@ public:
             }
         }
         loaded = false;
+    }
+
+    void uninitialize()
+    {
+        if (!initialized)
+            return;
+        ma_engine_uninit(&engine);
+        ma_context_uninit(&context);
+        initialized = false;
     }
 
     static std::string resolve_asset(const std::string &name)
@@ -98,6 +154,11 @@ public:
     bool loaded = false;
     bool enabled = true;
     mutable std::mutex mutex;
+    std::atomic<bool> cleanup_requested{false};
+    std::atomic<bool> cleanup_stop{false};
+    std::mutex cleanup_wait_mutex;
+    std::condition_variable cleanup_cv;
+    std::thread cleanup_thread;
 };
 
 Cp0SystemSoundPlayer::Cp0SystemSoundPlayer()
@@ -114,7 +175,8 @@ int Cp0SystemSoundPlayer::reload(const std::vector<std::string> &names)
         if (!names[i].empty())
             impl_->names[i] = names[i];
     impl_->unload();
-    return impl_->load();
+    impl_->uninitialize();
+    return 0;
 }
 
 bool Cp0SystemSoundPlayer::play_index(std::size_t index)
@@ -157,6 +219,10 @@ void Cp0SystemSoundPlayer::set_enabled(bool enabled)
 {
     std::lock_guard<std::mutex> lock(impl_->mutex);
     impl_->enabled = enabled;
+    if (!enabled) {
+        impl_->unload();
+        impl_->uninitialize();
+    }
 }
 
 bool Cp0SystemSoundPlayer::enabled() const

--- a/ext_components/cp0_lvgl/src/cp0/cp0_lvgl_audio.cpp
+++ b/ext_components/cp0_lvgl/src/cp0/cp0_lvgl_audio.cpp
@@ -8,12 +8,15 @@
 
 #include <algorithm>
 #include <atomic>
+#include <condition_variable>
+#include <cstdint>
 #include <functional>
 #include <iterator>
 #include <list>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -27,7 +30,10 @@ public:
     typedef std::function<void(int, std::string)> callback_t;
     typedef std::list<std::string> arg_t;
 
-    AudioSystem() = default;
+    AudioSystem()
+        : playback_cleanup_thread_(&AudioSystem::playback_cleanup_loop, this)
+    {
+    }
     ~AudioSystem()
     {
         shutdown();
@@ -35,9 +41,15 @@ public:
 
     void shutdown() noexcept
     {
+        if (shutdown_started_.exchange(true))
+            return;
         try { set_status_callback(nullptr); } catch (...) {}
         try { capture_.set_status_callback(nullptr); } catch (...) {}
         try { capture_.stop(); } catch (...) {}
+        playback_cleanup_stop_.store(true);
+        playback_cleanup_cv_.notify_one();
+        if (playback_cleanup_thread_.joinable())
+            playback_cleanup_thread_.join();
         try { stop_play_device(false); } catch (...) {}
     }
 
@@ -47,6 +59,15 @@ public:
     std::unique_ptr<ma_device>  ma_cp0_play_device;
     std::unique_ptr<ma_decoder> ma_cp0_play_decoder;
     std::atomic<bool> play_finished_reported_{false};
+    std::atomic<bool> playback_stopping_{false};
+    std::mutex playback_mutex_;
+    std::atomic<std::uint64_t> playback_generation_{0};
+    std::atomic<std::uint64_t> playback_cleanup_generation_{0};
+    std::atomic<bool> playback_cleanup_stop_{false};
+    std::atomic<bool> shutdown_started_{false};
+    std::mutex playback_cleanup_wait_mutex_;
+    std::condition_variable playback_cleanup_cv_;
+    std::thread playback_cleanup_thread_;
 
     Cp0SystemSoundPlayer system_sounds_;
     Cp0AudioMixerControl mixer_;
@@ -67,7 +88,11 @@ public:
             ma_silence_pcm_frames(silence, frameCount - framesRead, pDevice->playback.format, pDevice->playback.channels);
         }
         bool finished = (result == MA_AT_END || framesRead < frameCount);
-        if(finished && !self->play_finished_reported_.exchange(true)) {
+        if(finished && !self->playback_stopping_.load() &&
+           !self->play_finished_reported_.exchange(true)) {
+            self->playback_cleanup_generation_.store(
+                self->playback_generation_.load());
+            self->playback_cleanup_cv_.notify_one();
             auto callback = self->status_callback();
             cp0::audio::invoke_callback(callback, 0, "play over\n");
         }
@@ -78,17 +103,21 @@ public:
 
     int play(std::string wav)
     {
+        std::unique_lock<std::mutex> lock(playback_mutex_);
         ma_result result;
         ma_device_config deviceConfig;
-        stop_play_device(false);
+        stop_play_device_locked(false);
+        playback_generation_.fetch_add(1);
+        playback_cleanup_generation_.store(0);
         play_finished_reported_.store(false);
         ma_cp0_play_device = std::make_unique<ma_device>();
         ma_cp0_play_decoder = std::make_unique<ma_decoder>();
         result = ma_decoder_init_file(wav.c_str(), NULL, ma_cp0_play_decoder.get());
         if (result != MA_SUCCESS) {
-            report_status(-2, "Could not load file\n");
             ma_cp0_play_decoder.reset();
             ma_cp0_play_device.reset();
+            lock.unlock();
+            report_status(-2, "Could not load file\n");
             return -2;
         }
 
@@ -101,18 +130,20 @@ public:
 
         if (ma_device_init(NULL, &deviceConfig, ma_cp0_play_device.get()) != MA_SUCCESS) {
             ma_decoder_uninit(ma_cp0_play_decoder.get());
-            report_status(-3, "Failed to open playback device.\n");
             ma_cp0_play_decoder.reset();
             ma_cp0_play_device.reset();
+            lock.unlock();
+            report_status(-3, "Failed to open playback device.\n");
             return -3;
         }
 
         if (ma_device_start(ma_cp0_play_device.get()) != MA_SUCCESS) {
             ma_device_uninit(ma_cp0_play_device.get());
             ma_decoder_uninit(ma_cp0_play_decoder.get());
-            report_status(-4, "Failed to start playback device.\n");
             ma_cp0_play_decoder.reset();
             ma_cp0_play_device.reset();
+            lock.unlock();
+            report_status(-4, "Failed to start playback device.\n");
             return -4;
         }
 
@@ -128,6 +159,30 @@ public:
 
 
 private:
+    void playback_cleanup_loop()
+    {
+        std::unique_lock<std::mutex> wait_lock(playback_cleanup_wait_mutex_);
+        while (!playback_cleanup_stop_.load()) {
+            playback_cleanup_cv_.wait(wait_lock, [this] {
+                return playback_cleanup_stop_.load() ||
+                       playback_cleanup_generation_.load() != 0;
+            });
+            if (playback_cleanup_stop_.load())
+                break;
+
+            const std::uint64_t generation =
+                playback_cleanup_generation_.exchange(0);
+            wait_lock.unlock();
+            {
+                std::lock_guard<std::mutex> lock(playback_mutex_);
+                if (generation == playback_generation_.load() &&
+                    play_finished_reported_.load())
+                    stop_play_device_locked(false);
+            }
+            wait_lock.lock();
+        }
+    }
+
     callback_t status_callback()
     {
         std::lock_guard<std::mutex> lock(callback_mutex_);
@@ -177,6 +232,14 @@ private:
 
     void stop_play_device(bool report_state)
     {
+        std::lock_guard<std::mutex> lock(playback_mutex_);
+        stop_play_device_locked(report_state);
+    }
+
+    void stop_play_device_locked(bool report_state)
+    {
+        playback_stopping_.store(true);
+        playback_cleanup_generation_.store(0);
         play_finished_reported_.store(false);
         if(ma_cp0_play_device)
         {
@@ -188,6 +251,7 @@ private:
             ma_decoder_uninit(ma_cp0_play_decoder.get());
             ma_cp0_play_decoder.reset();
         }
+        playback_stopping_.store(false);
         if(report_state) report_status(0, "play stop\n");
     }
 
@@ -288,25 +352,39 @@ public:
     void PlayPause(arg_t arg, callback_t callback)
     {
         (void)arg;
-        if(!ma_cp0_play_device)
+        ma_result result = MA_INVALID_OPERATION;
+        bool started = false;
         {
-            report(callback, -1, "play not started\n");
-            return;
+            std::lock_guard<std::mutex> lock(playback_mutex_);
+            if(ma_cp0_play_device) {
+                started = true;
+                result = ma_device_stop(ma_cp0_play_device.get());
+            }
         }
-        ma_result ret = ma_device_stop(ma_cp0_play_device.get());
-        report(callback, ret == MA_SUCCESS ? 0 : -2, ret == MA_SUCCESS ? "play pause\n" : "play pause failed\n");
+        if(!started)
+            report(callback, -1, "play not started\n");
+        else
+            report(callback, result == MA_SUCCESS ? 0 : -2,
+                   result == MA_SUCCESS ? "play pause\n" : "play pause failed\n");
     }
 
     void PlayContinue(arg_t arg, callback_t callback)
     {
         (void)arg;
-        if(!ma_cp0_play_device)
+        ma_result result = MA_INVALID_OPERATION;
+        bool started = false;
         {
-            report(callback, -1, "play not started\n");
-            return;
+            std::lock_guard<std::mutex> lock(playback_mutex_);
+            if(ma_cp0_play_device) {
+                started = true;
+                result = ma_device_start(ma_cp0_play_device.get());
+            }
         }
-        ma_result ret = ma_device_start(ma_cp0_play_device.get());
-        report(callback, ret == MA_SUCCESS ? 0 : -2, ret == MA_SUCCESS ? "play continue\n" : "play continue failed\n");
+        if(!started)
+            report(callback, -1, "play not started\n");
+        else
+            report(callback, result == MA_SUCCESS ? 0 : -2,
+                   result == MA_SUCCESS ? "play continue\n" : "play continue failed\n");
     }
 
     void PlayEnd(arg_t arg, callback_t callback)

--- a/projects/APPLaunch/tests/test_adb_packaging.py
+++ b/projects/APPLaunch/tests/test_adb_packaging.py
@@ -13,9 +13,13 @@ sys.modules[spec.name] = packager
 spec.loader.exec_module(packager)
 
 postinst = packager._postinst_text(packager.PackageConfig())
+subprocess.run(["sh", "-n"], input=postinst, text=True, check=True)
 assert "/usr/share/APPLaunch/adb/cardputer-adb" in postinst
 assert '"$ADB_HELPER" migrate' in postinst
 assert 'user_systemctl restart "$SERVICE_NAME" || user_systemctl start "$SERVICE_NAME" || true' not in postinst
+assert 'systemctl --global enable "$SERVICE_NAME"' not in postinst
+assert 'systemctl --global disable "$SERVICE_NAME"' in postinst
+assert 'default.target.wants' in postinst
 
 system_postinst = packager._postinst_text(packager.PackageConfig(service_scope="system"))
 assert '"$ADB_HELPER" migrate' in system_postinst

--- a/projects/LaunchWizard/main/ui/service_handoff.cpp
+++ b/projects/LaunchWizard/main/ui/service_handoff.cpp
@@ -12,14 +12,32 @@ std::string command_error(const char *step, const HandoffCommandResult &result)
 
 }  // namespace
 
-std::string enable_applaunch_after_reboot(const HandoffCommandRunner &run)
+std::string enable_applaunch_after_reboot(const std::string &user,
+                                          unsigned int uid,
+                                          const HandoffCommandRunner &run)
 {
-    const HandoffCommandResult result = run({
-        "systemctl", "--global", "enable", "APPLaunch.service",
-    });
-    return result.code == 0
-        ? std::string()
-        : command_error("Failed to enable APPLaunch.service for next boot", result);
+    const std::string uid_text = std::to_string(uid);
+    const std::string runtime_dir = "XDG_RUNTIME_DIR=/run/user/" + uid_text;
+    const std::string bus_address =
+        "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/" + uid_text + "/bus";
+    const std::vector<std::vector<std::string>> commands = {
+        {"systemctl", "--global", "disable", "APPLaunch.service"},
+        {"loginctl", "enable-linger", user},
+        {"systemctl", "daemon-reload"},
+        {"systemctl", "start", "user@" + uid_text + ".service"},
+        {"runuser", "-u", user, "--", "env", runtime_dir, bus_address,
+         "systemctl", "--user", "daemon-reload"},
+        {"runuser", "-u", user, "--", "env", runtime_dir, bus_address,
+         "systemctl", "--user", "enable", "APPLaunch.service"},
+    };
+    for (const auto &command : commands) {
+        const HandoffCommandResult result = run(command);
+        if (result.code != 0)
+            return command_error(
+                "Failed to enable APPLaunch.service for the configured user",
+                result);
+    }
+    return {};
 }
 
 std::string handoff_to_applaunch(const std::string &user, unsigned int uid,
@@ -41,6 +59,11 @@ std::string handoff_to_applaunch(const std::string &user, unsigned int uid,
     };
 
     std::string error = required(
+        "Failed to remove global APPLaunch enablement",
+        {"systemctl", "--global", "disable", "APPLaunch.service"});
+    if (!error.empty()) return error;
+
+    error = required(
         "Failed to enable the APPLaunch user manager",
         {"loginctl", "enable-linger", user});
     if (!error.empty()) return error;

--- a/projects/LaunchWizard/main/ui/service_handoff.h
+++ b/projects/LaunchWizard/main/ui/service_handoff.h
@@ -15,9 +15,11 @@ struct HandoffCommandResult {
 using HandoffCommandRunner =
     std::function<HandoffCommandResult(const std::vector<std::string> &)>;
 
-// Enables APPLaunch for future user sessions without requiring a running user
-// manager or D-Bus session during first-boot configuration.
-std::string enable_applaunch_after_reboot(const HandoffCommandRunner &run);
+// Enables APPLaunch only for the configured account. The user manager is
+// started explicitly so this does not create a global link for greeter users.
+std::string enable_applaunch_after_reboot(const std::string &user,
+                                          unsigned int uid,
+                                          const HandoffCommandRunner &run);
 
 // Starts and verifies APPLaunch before stopping LaunchWizard. On failure the
 // remaining commands are not run, so the currently visible wizard stays up.

--- a/projects/LaunchWizard/main/ui/wizard_service.cpp
+++ b/projects/LaunchWizard/main/ui/wizard_service.cpp
@@ -647,15 +647,16 @@ std::string configure_desktop_startup(const std::string &user)
     }
     if (!command_ok({"chmod", "0644",
                      "/etc/lightdm/lightdm.conf.d/50-launchwizard-autologin.conf"}, warning) ||
-        !command_ok({"systemctl", "enable", "lightdm.service"}, warning))
+        !command_ok({"systemctl", "disable", "lightdm.service"}, warning))
         return warning;
 
     return warning;
 }
 
-std::string enable_applaunch_service()
+std::string enable_applaunch_service(const std::string &user, unsigned int uid)
 {
     return enable_applaunch_after_reboot(
+        user, uid,
         [](const std::vector<std::string> &args) {
             CommandResult result = run_command(args);
             return HandoffCommandResult{result.code, result.output};
@@ -926,7 +927,7 @@ std::string WizardService::apply(
             const struct passwd *account = getpwnam(username.c_str());
             if (!account || account->pw_uid == 0)
                 return std::string("Configured user account is unavailable");
-            return enable_applaunch_service();
+            return enable_applaunch_service(username, account->pw_uid);
         }),
         best_effort("Finalizing configuration...", [] {
             std::string first_error;

--- a/projects/LaunchWizard/tests/test_service_handoff.cpp
+++ b/projects/LaunchWizard/tests/test_service_handoff.cpp
@@ -31,21 +31,26 @@ bool test_service_handoff()
 
     std::vector<std::string> calls;
     std::string error = enable_applaunch_after_reboot(
+        "cardputer", 1000,
         [&calls](const std::vector<std::string> &args) {
             calls.push_back(joined(args));
             return HandoffCommandResult{};
         });
     expect(error.empty(), "next-boot APPLaunch enable returned an error");
-    expect(calls.size() == 1, "next-boot enable must execute exactly one command");
-    if (calls.size() == 1) {
-        expect(calls[0] == "systemctl --global enable APPLaunch.service",
-               "next-boot enable did not use global user-service configuration");
-        expect(calls[0].find("--now") == std::string::npos,
+    expect(calls.size() == 6, "next-boot enable did not run all user-scoped steps");
+    if (calls.size() == 6) {
+        expect(calls[0] == "systemctl --global disable APPLaunch.service",
+               "next-boot enable did not remove legacy global configuration");
+        expect(calls[5].find("systemctl --user enable APPLaunch.service") !=
+                   std::string::npos,
+               "next-boot enable was not scoped to the configured user");
+        expect(calls[5].find("--now") == std::string::npos,
                "configuration phase attempted to start APPLaunch");
     }
 
     calls.clear();
     error = enable_applaunch_after_reboot(
+        "cardputer", 1000,
         [&calls](const std::vector<std::string> &args) {
             calls.push_back(joined(args));
             return HandoffCommandResult{1, "injected enable failure"};
@@ -60,17 +65,19 @@ bool test_service_handoff()
             return HandoffCommandResult{};
         });
     expect(error.empty(), "successful handoff returned an error");
-    expect(calls.size() == 7, "successful handoff did not run all steps");
-    if (calls.size() == 7) {
-        expect(calls[4].find("enable --now APPLaunch.service") != std::string::npos,
+    expect(calls.size() == 8, "successful handoff did not run all steps");
+    if (calls.size() == 8) {
+        expect(calls[0] == "systemctl --global disable APPLaunch.service",
+               "handoff did not remove legacy global configuration");
+        expect(calls[5].find("enable --now APPLaunch.service") != std::string::npos,
                "APPLaunch was not started while being enabled");
-        expect(calls[5].find("is-active --quiet APPLaunch.service") != std::string::npos,
+        expect(calls[6].find("is-active --quiet APPLaunch.service") != std::string::npos,
                "APPLaunch active state was not verified");
-        expect(calls[6] == "systemctl disable --now LaunchWizard.service",
+        expect(calls[7] == "systemctl disable --now LaunchWizard.service",
                "LaunchWizard was not stopped last");
     }
 
-    for (size_t failed_step = 0; failed_step < 6; ++failed_step) {
+    for (size_t failed_step = 0; failed_step < 7; ++failed_step) {
         calls.clear();
         error = handoff_to_applaunch(
             "cardputer", 1000,
@@ -96,7 +103,7 @@ bool test_service_handoff()
     error = handoff_to_applaunch(
         "cardputer", 1000, [&calls](const std::vector<std::string> &args) {
             calls.push_back(joined(args));
-            if (calls.size() == 7)
+            if (calls.size() == 8)
                 return HandoffCommandResult{1, "disable failed"};
             return HandoffCommandResult{};
         });

--- a/scripts/build_cardputerzero_release_local.sh
+++ b/scripts/build_cardputerzero_release_local.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+    echo "usage: $0 <debian-version> [revision]" >&2
+    echo "example: $0 0.6.29+local.audiofix5 1" >&2
+    exit 2
+fi
+
+VERSION=$1
+REVISION=${2:-1}
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+JOBS=${JOBS:-$(nproc)}
+OUTPUT_DIR=${OUTPUT_DIR:-"$ROOT/../build-artifacts/launcher-release"}
+SCONS=${SCONS:-scons}
+
+for command in aarch64-linux-gnu-g++ dpkg-deb python3; do
+    if ! command -v "$command" >/dev/null 2>&1; then
+        echo "ERROR: required command not found: $command" >&2
+        exit 1
+    fi
+done
+if ! command -v "$SCONS" >/dev/null 2>&1 && [ ! -x "$SCONS" ]; then
+    echo "ERROR: SCons not found: $SCONS" >&2
+    echo "Set SCONS to the venv executable, for example:" >&2
+    echo "  SCONS=/home/m5stack/.venvs/cardputerzero-build/bin/scons" >&2
+    exit 1
+fi
+
+for project in APPLaunch AppStore Calculator LaunchWizard ZClaw; do
+    if [ ! -f "$ROOT/projects/$project/SConstruct" ]; then
+        echo "ERROR: missing project or submodule: projects/$project/SConstruct" >&2
+        exit 1
+    fi
+done
+
+export CardputerZero=y
+export CONFIG_REPO_AUTOMATION=y
+export APPLAUNCH_VERSION=${APPLAUNCH_VERSION:-${VERSION%%+*}}
+export APPLAUNCH_CHANNEL=${APPLAUNCH_CHANNEL:-local}
+export SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-$(git -C "$ROOT" show -s --format=%ct HEAD)}
+
+build_project() {
+    project=$1
+    echo "=== Building $project for CardputerZero ARM64 ==="
+    (
+        cd "$ROOT/projects/$project"
+        "$SCONS" -j"$JOBS" --implicit-deps-changed
+    )
+}
+
+build_project APPLaunch
+build_project AppStore
+build_project Calculator
+build_project LaunchWizard
+build_project ZClaw
+
+echo "=== Aggregating release payload ==="
+install -d "$ROOT/projects/APPLaunch/dist/bin"
+install -m 0755 "$ROOT/projects/AppStore/dist/M5CardputerZero-AppStore" \
+    "$ROOT/projects/APPLaunch/dist/bin/"
+install -m 0755 "$ROOT/projects/Calculator/dist/M5CardputerZero-Calculator" \
+    "$ROOT/projects/APPLaunch/dist/bin/"
+install -m 0755 "$ROOT/projects/ZClaw/dist/ZClaw" \
+    "$ROOT/projects/APPLaunch/dist/bin/"
+
+install -d "$ROOT/projects/APPLaunch/dist/APPLaunch"
+cp -a "$ROOT/projects/AppStore/dist/APPLaunch/." \
+    "$ROOT/projects/APPLaunch/dist/APPLaunch/"
+cp -a "$ROOT/projects/ZClaw/dist/APPLaunch/." \
+    "$ROOT/projects/APPLaunch/dist/APPLaunch/"
+install -D -m 0755 "$ROOT/projects/LaunchWizard/dist/LaunchWizard" \
+    "$ROOT/projects/APPLaunch/dist/APPLaunch/bin/LaunchWizard"
+
+install -d "$OUTPUT_DIR"
+python3 "$ROOT/scripts/debian_packager.py" build \
+    --project APPLaunch \
+    --package-name applaunch \
+    --app-name APPLaunch \
+    --bin-name M5CardputerZero-APPLaunch \
+    --version "$VERSION" \
+    --revision "$REVISION" \
+    --architecture arm64 \
+    --output-dir "$OUTPUT_DIR"
+
+PACKAGE="$OUTPUT_DIR/applaunch_${VERSION}-${REVISION}_arm64.deb"
+test -f "$PACKAGE"
+test "$(dpkg-deb -f "$PACKAGE" Architecture)" = arm64
+CONTENTS=$(mktemp)
+trap 'rm -f "$CONTENTS"' EXIT
+dpkg-deb -c "$PACKAGE" >"$CONTENTS"
+grep -q './usr/share/APPLaunch/bin/LaunchWizard$' "$CONTENTS"
+grep -q './usr/share/APPLaunch/bin/M5CardputerZero-APPLaunch$' "$CONTENTS"
+
+echo "=== Release package ==="
+dpkg-deb -f "$PACKAGE" Package Version Architecture
+stat -c '%s %n' "$PACKAGE"
+sha256sum "$PACKAGE"

--- a/scripts/debian_packager.py
+++ b/scripts/debian_packager.py
@@ -228,40 +228,51 @@ set -e
 mkdir -p /var/cache/{config.app_name}
 chown 1000:1000 /var/cache/{config.app_name} || true
 ln -sfn /var/cache/{config.app_name} /usr/share/{config.app_name}/cache
-APP_UID=1000
-APP_USER="$(getent passwd "$APP_UID" | cut -d: -f1)"
-SERVICE_NAME="{service_name}"
-SERVICE_FILE="{service_file}"
-{adb_migration}
+	APP_UID=1000
+	APP_USER="$(getent passwd "$APP_UID" | cut -d: -f1)"
+	APP_GID="$(getent passwd "$APP_UID" | cut -d: -f4)"
+	APP_HOME="$(getent passwd "$APP_UID" | cut -d: -f6)"
+	SERVICE_NAME="{service_name}"
+	SERVICE_FILE="{service_file}"
+	{adb_migration}
 
 systemd_is_running() {{
     [ -d /run/systemd/system ] && [ "$(ps -p 1 -o comm= 2>/dev/null)" = "systemd" ]
 }}
 
-user_systemctl() {{
+	user_systemctl() {{
     runuser -u "$APP_USER" -- env \\
         XDG_RUNTIME_DIR="/run/user/$APP_UID" \\
         DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$APP_UID/bus" \\
-        systemctl --user "$@"
-}}
+	        systemctl --user "$@"
+	}}
 
-if command -v systemctl >/dev/null 2>&1 && [ -f "$SERVICE_FILE" ]; then
-    systemctl --global enable "$SERVICE_NAME"
-    if systemd_is_running && [ -n "$APP_USER" ]; then
+	enable_user_service_offline() {{
+	    USER_WANTS="$APP_HOME/.config/systemd/user/default.target.wants"
+	    install -d -m 0755 -o "$APP_UID" -g "$APP_GID" "$USER_WANTS"
+	    ln -sfn "$SERVICE_FILE" "$USER_WANTS/$SERVICE_NAME"
+	    chown -h "$APP_UID:$APP_GID" "$USER_WANTS/$SERVICE_NAME"
+	}}
+
+	if command -v systemctl >/dev/null 2>&1 && [ -f "$SERVICE_FILE" ]; then
+	    # A global user-service link starts the launcher in greeter and service
+	    # accounts too. Remove legacy global enablement and scope it to UID 1000.
+	    systemctl --global disable "$SERVICE_NAME" || true
+	    if systemd_is_running && [ -n "$APP_USER" ]; then
         if command -v loginctl >/dev/null 2>&1; then
             loginctl enable-linger "$APP_USER" || true
         fi
         systemctl daemon-reload
         systemctl start "user@$APP_UID.service"
         user_systemctl daemon-reload
-        user_systemctl enable "$SERVICE_NAME"
-        user_systemctl restart "$SERVICE_NAME" || user_systemctl start "$SERVICE_NAME"
-    else
-        echo "{config.app_name}: systemd is not running; enabled user service globally for first boot" >&2
-        if [ -z "$APP_USER" ]; then
-            echo "{config.app_name}: UID 1000 user not found; skip immediate user service start" >&2
-        fi
-    fi
+	        user_systemctl enable "$SERVICE_NAME"
+	        user_systemctl restart "$SERVICE_NAME" || user_systemctl start "$SERVICE_NAME"
+	    elif [ -n "$APP_USER" ]; then
+	        enable_user_service_offline
+	        echo "{config.app_name}: enabled user service for UID $APP_UID on first boot" >&2
+	    else
+	        echo "{config.app_name}: UID 1000 user not found; skip user service enable/start" >&2
+	    fi
 else
     echo "{config.app_name}: systemctl unavailable or service file missing; skip user service enable/start" >&2
 fi
@@ -297,8 +308,9 @@ exit 0
 """
     return f"""#!/bin/sh
 set -e
-APP_UID=1000
-APP_USER="$(getent passwd "$APP_UID" | cut -d: -f1)"
+	APP_UID=1000
+	APP_USER="$(getent passwd "$APP_UID" | cut -d: -f1)"
+	APP_HOME="$(getent passwd "$APP_UID" | cut -d: -f6)"
 SERVICE_NAME="{service_name}"
 SERVICE_FILE="{service_file}"
 
@@ -320,7 +332,10 @@ case "$1" in
                 user_systemctl stop "$SERVICE_NAME" || true
                 user_systemctl disable "$SERVICE_NAME" || true
             fi
-            systemctl --global disable "$SERVICE_NAME" || true
+	            systemctl --global disable "$SERVICE_NAME" || true
+	            if [ -n "$APP_HOME" ]; then
+	                rm -f "$APP_HOME/.config/systemd/user/default.target.wants/$SERVICE_NAME"
+	            fi
         fi
         rm -rf /var/cache/{config.app_name}
         ;;


### PR DESCRIPTION
## Summary\n- release miniaudio playback devices after idle/system-sound completion\n- serialize EOF/manual-stop cleanup outside audio callbacks\n- enable APPLaunch only for the product user and remove stale global enable links\n- add a complete local CardputerZero launcher release package entry point\n\n## Validation\n- targeted audio runtime, mixer and API contract tests: pass\n- LaunchWizard CMake/CTest: pass\n- APPLaunch ADB packaging test: pass\n- complete ARM64 launcher package previously built and integrated into the verified local image\n\n## Known test issue\nThe full cp0_lvgl test runner currently reaches an unrelated external-process/ESC-timeout test and terminates with a segmentation fault. This PR is opened as draft until that baseline/process-runner failure is resolved or isolated.