### PR TITLE
ci: 把 cp0_lvgl 单元测试套件接入门禁

### DIFF
--- a/.github/workflows/launcher-build.yml
+++ b/.github/workflows/launcher-build.yml
@@ -233,7 +233,7 @@ jobs:
 
     - name: Lower ASLR entropy (Ubuntu 24.04 mmap_rnd_bits exceeds what ThreadSanitizer can map)
       run: |
-        bits=$(cat /proc/sys/vm/mmap_rnd_bits)
+        bits=$(sudo sysctl -n vm.mmap_rnd_bits 2>/dev/null || echo 0)
         if [ "$bits" -gt 28 ]; then
           sudo sysctl -w vm.mmap_rnd_bits=28
         fi

--- a/.github/workflows/launcher-build.yml
+++ b/.github/workflows/launcher-build.yml
@@ -203,8 +203,46 @@ jobs:
         name: applaunch-arm64
         path: artifacts/
 
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Initialize submodules (SDK)
+      run: git submodule update --init --depth=1 SDK
+
+    - name: Install test dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libxkbcommon-dev
+
+    - name: Pre-download eventpp headers (pinned to the revision scons resolves)
+      run: |
+        REF=c472fb22e71ead0e58ff7df89e12c66b0bdfb533
+        DEST=SDK/github_source/eventpp
+        if [ ! -d "$DEST" ]; then
+          for i in 1 2 3; do
+            curl -fsSL -o /tmp/eventpp.zip "https://github.com/wqking/eventpp/archive/${REF}.zip" && break
+            echo "retry $i..."; sleep 5
+          done
+          mkdir -p SDK/github_source
+          unzip -q /tmp/eventpp.zip -d /tmp/eventpp
+          mv "/tmp/eventpp/eventpp-${REF}" "$DEST"
+        fi
+        ls "$DEST/include/eventpp/callbacklist.h" && echo "eventpp ready"
+
+    - name: Lower ASLR entropy (Ubuntu 24.04 mmap_rnd_bits exceeds what ThreadSanitizer can map)
+      run: |
+        bits=$(cat /proc/sys/vm/mmap_rnd_bits)
+        if [ "$bits" -gt 28 ]; then
+          sudo sysctl -w vm.mmap_rnd_bits=28
+        fi
+
+    - name: Run cp0_lvgl unit tests
+      run: sh ext_components/cp0_lvgl/tests/run_tests.sh
+
   prerelease:
-    needs: build
+    needs: [build, unit-tests]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## 背景

`ext_components/cp0_lvgl/tests/run_tests.sh` 有 80+ 个用例，但**从来没有进过 CI**：`launcher-build.yml` 只做交叉编译和打包，`emulator-build.yml` 只做 cmake 构建，两个都不会调这个脚本。后果是这套测试长期处于「没人跑、跑了也不知道该不该绿」的状态，还直接误导了一次 PR 评审（见下）。

## 改动

新增 `unit-tests` job，并让 `prerelease` 依赖它，这样测试红了不会发预发布。跑这套测试需要三样东西：

- `libxkbcommon-dev`（`test_keyboard_keymap` 要 `-lxkbcommon`）
- SDK 子模块（`cp0_keyboard_keymap.c` 相对引用了 `SDK/components/utilities/include/sample_log.h`）
- pinned 的 eventpp 头（脚本硬编码 `SDK/github_source/eventpp/include`，这里用 scons 实际解析到的那个 revision `c472fb2`）

## 顺手修掉的环境失败

整套测试在 Ubuntu 24.04 上跑到最后一个用例 `test_esc_state_tsan` 会直接死掉：

```
FATAL: ThreadSanitizer: unexpected memory mapping 0xbcc81ab10000-0xbcc81ab12000
```

原因是 24.04 把 `vm.mmap_rnd_bits` 调到了 TSan 能映射的范围之外，跟被测代码无关。降到 28 之后整套 `EXIT=0` 全绿。

**这一条正是 #138 挂 draft 的原因。** 那个 PR 说「跑到 external-process/ESC-timeout 用例出现段错误」——实际上 ESC-timeout 的日志是它前面一个用例的正常输出，崩的是紧随其后的 `test_esc_state_tsan`，也就是这里修掉的这个环境问题（TSan 在这种 ASLR 布局下按工具链版本不同，可能打印 FATAL，也可能直接 SIGSEGV）。#138 在 cp0_lvgl 里只改了 `cp0_lvgl_audio.cpp` 和 `cp0_audio_system_sound_player.cpp`，而 `run_tests.sh` 一条命令都没编译这两个文件，所以它的改动跟这个崩溃没有因果关系。

## 验证

在 Ubuntu 24.04 + gcc 13.3.0（与 `ubuntu-latest` 相同）的容器里，对**不含任何本地改动的 origin/master** 跑：

- 降 `mmap_rnd_bits` 前：`EXIT=66`，死在 TSan 用例
- 降之后：`EXIT=0`，全套通过
- 另外把 `test_process_command_timeout` 和 `test_external_process_group` 单独压了 80 次：`FAILURES=0 SEGV=0`

## 暂未纳入

- `projects/APPLaunch/tests/run_tests.sh`：卡在 `test_cardputer_adb.sh`（纯 mock 的用例，master 上就是红的，需要单独查）
- `projects/ZClaw/tests/run_tests.sh`：需要 libhv 头（`hv/HttpClient.h`）
- `projects/LaunchWizard/tests/`：有 6 个用例但没有 runner 脚本
