### PR TITLE
fix: preserve CardputerZero settings and release workflows

### DIFF
--- a/.github/workflows/launcher-build.yml
+++ b/.github/workflows/launcher-build.yml
@@ -15,6 +15,8 @@ on:
       - 'ext_components/**'
       - '.gitmodules'
       - '.github/workflows/launcher-build.yml'
+      - 'scripts/build_cardputerzero_release_local.sh'
+      - 'scripts/cardputer_adb_hotplug.c'
       - 'scripts/debian_packager.py'
   pull_request:
     branches: [master]
@@ -186,7 +188,11 @@ jobs:
 
     - name: Build .deb package
       run: |
-        python3 scripts/debian_packager.py --version "${{ steps.version.outputs.version }}"
+        SCONS=scons \
+          OUTPUT_DIR="$GITHUB_WORKSPACE/projects/APPLaunch/tools" \
+          APPLAUNCH_CHANNEL=prerelease \
+          scripts/build_cardputerzero_release_local.sh \
+            "${{ steps.version.outputs.version }}" 1
 
     - name: Collect artifacts
       run: |
@@ -197,6 +203,7 @@ jobs:
         test "$(printf '%s\n' "${package}" | sed '/^$/d' | wc -l)" -eq 1
         cp "${package}" artifacts/applaunch_arm64.deb
         (cd artifacts && sha256sum applaunch_arm64.deb > applaunch_arm64.deb.sha256)
+        printf '1\n' > artifacts/applaunch_arm64.deb.update-abi
 
     - uses: actions/upload-artifact@v4
       with:
@@ -263,6 +270,7 @@ jobs:
         files: |
           artifacts/*.deb
           artifacts/*.sha256
+          artifacts/*.update-abi
           artifacts/M5CardputerZero-APPLaunch
 
     - name: Publish launcher update channel
@@ -275,3 +283,4 @@ jobs:
         files: |
           artifacts/applaunch_arm64.deb
           artifacts/applaunch_arm64.deb.sha256
+          artifacts/applaunch_arm64.deb.update-abi

--- a/ext_components/cp0_lvgl/src/commount.cpp
+++ b/ext_components/cp0_lvgl/src/commount.cpp
@@ -138,6 +138,16 @@ static void saved_volume_write(int val)
     });
 }
 
+static void saved_gpio_write(const char *name)
+{
+    const int value = config_get_int(name, -1);
+    if (value != 0 && value != 1)
+        return;
+    cp0::signal::invoke_noexcept([&] {
+        cp0_signal_settings_api({"GpioSet", name, std::to_string(value)}, nullptr);
+    });
+}
+
 extern "C" void init_lvgl_saved_settings()
 {
     int saved_bright = config_get_int("brightness", -1);
@@ -147,4 +157,7 @@ extern "C" void init_lvgl_saved_settings()
     int saved_vol = config_get_int("volume", -1);
     if (saved_vol >= 0)
         saved_volume_write(saved_vol);
+
+    saved_gpio_write("extport_usb");
+    saved_gpio_write("extport_5vout");
 }

--- a/ext_components/cp0_lvgl/src/cp0/cp0_audio_system_sound_player.cpp
+++ b/ext_components/cp0_lvgl/src/cp0/cp0_audio_system_sound_player.cpp
@@ -1,13 +1,12 @@
 #include "cp0_audio_system_sound_player.hpp"
+#include "../cp0_audio_quiet_period_gate.hpp"
 
 #include "hal_lvgl_bsp.h"
 #include "miniaudio.h"
 
 #include <algorithm>
 #include <array>
-#include <atomic>
 #include <chrono>
-#include <condition_variable>
 #include <mutex>
 #include <thread>
 
@@ -15,6 +14,7 @@ class Cp0SystemSoundPlayer::Impl
 {
 public:
     static constexpr std::size_t kSoundCount = 3;
+    static constexpr auto kCleanupGracePeriod = std::chrono::milliseconds(800);
 
     Impl()
         : names{"Ding2.wav", "key_back.wav", "key_back.wav"}
@@ -24,8 +24,7 @@ public:
 
     ~Impl()
     {
-        cleanup_stop.store(true);
-        cleanup_cv.notify_one();
+        cleanup_gate.stop();
         if (cleanup_thread.joinable())
             cleanup_thread.join();
 
@@ -37,35 +36,25 @@ public:
     static void sound_end_callback(void *user_data, ma_sound *)
     {
         auto *self = static_cast<Impl *>(user_data);
-        self->cleanup_requested.store(true);
-        self->cleanup_cv.notify_one();
+        try {
+            self->cleanup_gate.request();
+        } catch (...) {
+        }
     }
 
     void cleanup_loop()
     {
-        std::unique_lock<std::mutex> wait_lock(cleanup_wait_mutex);
-        while (!cleanup_stop.load()) {
-            cleanup_cv.wait(wait_lock, [this] {
-                return cleanup_stop.load() || cleanup_requested.load();
-            });
-            if (cleanup_stop.load())
-                break;
-
-            cleanup_requested.store(false);
-            wait_lock.unlock();
-            std::this_thread::sleep_for(std::chrono::milliseconds(20));
-            {
-                std::lock_guard<std::mutex> lock(mutex);
-                bool playing = false;
-                for (std::size_t i = 0; i < slots.size(); ++i)
-                    playing = playing ||
-                              (slots[i] && ma_sound_is_playing(&sounds[i]));
-                if (!playing) {
-                    unload();
-                    uninitialize();
-                }
+        while (const std::uint64_t generation =
+                   cleanup_gate.wait_until_quiet(kCleanupGracePeriod)) {
+            std::lock_guard<std::mutex> lock(mutex);
+            bool playing = false;
+            for (std::size_t i = 0; i < slots.size(); ++i)
+                playing = playing ||
+                          (slots[i] && ma_sound_is_playing(&sounds[i]));
+            if (!playing && cleanup_gate.current(generation)) {
+                unload();
+                uninitialize();
             }
-            wait_lock.lock();
         }
     }
 
@@ -154,10 +143,7 @@ public:
     bool loaded = false;
     bool enabled = true;
     mutable std::mutex mutex;
-    std::atomic<bool> cleanup_requested{false};
-    std::atomic<bool> cleanup_stop{false};
-    std::mutex cleanup_wait_mutex;
-    std::condition_variable cleanup_cv;
+    cp0::audio::QuietPeriodGate cleanup_gate;
     std::thread cleanup_thread;
 };
 
@@ -188,8 +174,11 @@ bool Cp0SystemSoundPlayer::play_index(std::size_t index)
     ma_sound *sound = &impl_->sounds[index];
     if (ma_sound_is_playing(sound))
         return true;
-    return ma_sound_seek_to_pcm_frame(sound, 0) == MA_SUCCESS &&
-           ma_sound_start(sound) == MA_SUCCESS;
+    const bool started = ma_sound_seek_to_pcm_frame(sound, 0) == MA_SUCCESS &&
+                         ma_sound_start(sound) == MA_SUCCESS;
+    if (started)
+        impl_->cleanup_gate.request();
+    return started;
 }
 
 bool Cp0SystemSoundPlayer::play_named(const std::string &name)
@@ -203,8 +192,11 @@ bool Cp0SystemSoundPlayer::play_named(const std::string &name)
         ma_sound *sound = &impl_->sounds[i];
         if (ma_sound_is_playing(sound))
             return true;
-        return ma_sound_seek_to_pcm_frame(sound, 0) == MA_SUCCESS &&
-               ma_sound_start(sound) == MA_SUCCESS;
+        const bool started = ma_sound_seek_to_pcm_frame(sound, 0) == MA_SUCCESS &&
+                             ma_sound_start(sound) == MA_SUCCESS;
+        if (started)
+            impl_->cleanup_gate.request();
+        return started;
     }
     return false;
 }

--- a/ext_components/cp0_lvgl/src/cp0/cp0_lvgl_osinfo.cpp
+++ b/ext_components/cp0_lvgl/src/cp0/cp0_lvgl_osinfo.cpp
@@ -118,19 +118,13 @@ private:
     static cp0::update::Result update_launcher(const std::atomic<bool> &cancel)
     {
         auto timeout_for = [](const std::vector<std::string> &arguments) {
-            if (!arguments.empty() && arguments.front() == "wget") return 120000;
-            if (!arguments.empty() && arguments.front() == "dpkg") return 300000;
+            if (!arguments.empty() && arguments.front() == "systemctl") return 1200000;
             return 30000;
         };
-        auto argv = [&cancel](const std::vector<std::string> &arguments) {
+        auto argv = [timeout_for, &cancel](const std::vector<std::string> &arguments) {
             std::string ignored;
-            const int timeout = !arguments.empty() && arguments.front() == "wget"
-                                    ? 120000
-                                    : (!arguments.empty() && arguments.front() == "dpkg"
-                                           ? 300000
-                                           : 30000);
             return cp0_process_commands::capture_argv_with_timeout(
-                arguments, ignored, timeout, &cancel);
+                arguments, ignored, timeout_for(arguments), &cancel);
         };
         auto capture = [timeout_for, &cancel](const std::vector<std::string> &arguments,
                                      std::string &output) {

--- a/ext_components/cp0_lvgl/src/cp0/cp0_lvgl_process.cpp
+++ b/ext_components/cp0_lvgl/src/cp0/cp0_lvgl_process.cpp
@@ -102,9 +102,14 @@ public:
         } else if (cmd == "AdbStatus") {
             if (!cp0_process_api_contract::has_exact_arguments(arg, 1)) return invalid(callback);
             std::string output;
-            const int result = cp0_process_commands::capture_argv(
+            const int active_result = cp0_process_commands::capture_argv(
                 {"systemctl", "is-active", "adbd.service"}, output);
-            report(callback, 0, result == 0 ? "adbd=active\n" : "adbd=inactive\n");
+            std::string enabled_output;
+            const int enabled_result = cp0_process_commands::capture_argv(
+                {"systemctl", "is-enabled", "adbd.service"}, enabled_output);
+            output = active_result == 0 ? "adbd=active\n" : "adbd=inactive\n";
+            output += enabled_result == 0 ? "enabled=enabled\n" : "enabled=disabled\n";
+            report(callback, 0, output);
         } else if (cmd == "DesktopExecIsSafe") {
             const auto *exec = cp0_process_api_contract::argument_at(arg, 1);
             if (!cp0_process_api_contract::has_exact_arguments(arg, 2) || !exec || exec->empty())

--- a/ext_components/cp0_lvgl/src/cp0/cp0_lvgl_settings.cpp
+++ b/ext_components/cp0_lvgl/src/cp0/cp0_lvgl_settings.cpp
@@ -384,8 +384,9 @@ private:
                 return -EIO;
             int value = 0;
             return cp0::settings::parse_integer_file_line(
-                       std::string_view(buf, static_cast<std::size_t>(size)), 0, 1, value)
-                       ? value
+                       std::string_view(buf, static_cast<std::size_t>(size)), 0,
+                       std::numeric_limits<int>::max(), value)
+                       ? cp0::settings::switch_value(value)
                        : -EINVAL;
         }
         return -ENOENT;

--- a/ext_components/cp0_lvgl/src/cp0_audio_quiet_period_gate.hpp
+++ b/ext_components/cp0_lvgl/src/cp0_audio_quiet_period_gate.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+
+namespace cp0::audio {
+
+class QuietPeriodGate
+{
+public:
+    void request()
+    {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (++generation_ == 0)
+                ++generation_;
+        }
+        cv_.notify_one();
+    }
+
+    void stop()
+    {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            stopped_ = true;
+        }
+        cv_.notify_one();
+    }
+
+    template <class Rep, class Period>
+    std::uint64_t wait_until_quiet(
+        const std::chrono::duration<Rep, Period> &quiet_period)
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        cv_.wait(lock, [this] {
+            return stopped_ || generation_ != observed_generation_;
+        });
+
+        while (!stopped_) {
+            observed_generation_ = generation_;
+            if (!cv_.wait_for(lock, quiet_period, [this] {
+                    return stopped_ || generation_ != observed_generation_;
+                }))
+                return observed_generation_;
+        }
+        return 0;
+    }
+
+    bool current(std::uint64_t generation) const
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return !stopped_ && generation != 0 && generation == generation_;
+    }
+
+private:
+    mutable std::mutex mutex_;
+    std::condition_variable cv_;
+    std::uint64_t generation_ = 0;
+    std::uint64_t observed_generation_ = 0;
+    bool stopped_ = false;
+};
+
+} // namespace cp0::audio

--- a/ext_components/cp0_lvgl/src/cp0_launcher_updater.hpp
+++ b/ext_components/cp0_lvgl/src/cp0_launcher_updater.hpp
@@ -36,52 +36,23 @@ inline bool checksum_value(const std::string &text, std::string &hash)
 
 inline Result launcher(const Run &run, const Capture &capture)
 {
-    char directory[] = "/tmp/applaunch-update-XXXXXX";
-    if (!mkdtemp(directory)) return {-1, "prepare"};
-    if (chmod(directory, 0700) != 0) {
-        rmdir(directory);
-        return {-1, "prepare"};
+    // The fixed system unit owns download, verification, rollback and install.
+    // Keeping that work in one process avoids downloading the same package
+    // twice and lets slow links use the unit's full timeout.
+    const int code = run({"systemctl", "start", "applaunch-updater.service"});
+    std::string state;
+    if (capture({"cat", "/var/lib/applaunch-updater/status"}, state) == 0) {
+        state = trim(std::move(state));
+        if (code == 0 && state.rfind("succeeded:", 0) == 0)
+            return {0, state.substr(10)};
+        if (state.rfind("failed:", 0) == 0) {
+            std::string stage = state.substr(7);
+            const size_t detail = stage.find(':');
+            if (detail != std::string::npos) stage.resize(detail);
+            return {code == 0 ? -1 : code, stage.empty() ? "service" : stage};
+        }
     }
-    const std::string base(directory);
-    const std::string package = base + "/applaunch_arm64.deb";
-    const std::string checksum = base + "/applaunch_arm64.deb.sha256";
-    auto finish = [&](Result result) {
-        std::remove(package.c_str());
-        std::remove(checksum.c_str());
-        rmdir(base.c_str());
-        return result;
-    };
-    const std::string release =
-        "https://github.com/CardputerZero/launcher/releases/download/launcher-latest/";
-    if (run({"wget", "-q", "--https-only", release + "applaunch_arm64.deb", "-O", package}) != 0)
-        return finish({-1, "download-package"});
-    if (run({"wget", "-q", "--https-only", release + "applaunch_arm64.deb.sha256", "-O", checksum}) != 0)
-        return finish({-1, "download-checksum"});
-
-    std::string expected, checksum_text, actual;
-    if (capture({"cat", checksum}, checksum_text) != 0 || !checksum_value(checksum_text, expected))
-        return finish({-1, "checksum-manifest"});
-    if (capture({"sha256sum", package}, actual) != 0 || actual.size() < 64 || actual.substr(0, 64) != expected)
-        return finish({-1, "checksum"});
-
-    std::string name, architecture, candidate, installed;
-    if (capture({"dpkg-deb", "-f", package, "Package"}, name) != 0 || trim(name) != "applaunch")
-        return finish({-1, "package-name"});
-    if (capture({"dpkg-deb", "-f", package, "Architecture"}, architecture) != 0 ||
-        trim(architecture) != "arm64")
-        return finish({-1, "architecture"});
-    if (capture({"dpkg-deb", "-f", package, "Version"}, candidate) != 0 || trim(candidate).empty())
-        return finish({-1, "candidate-version"});
-    if (capture({"dpkg-query", "-W", "-f=${Version}", "applaunch"}, installed) != 0 || trim(installed).empty())
-        return finish({-1, "installed-version"});
-    if (run({"dpkg", "--compare-versions", trim(candidate), "gt", trim(installed)}) != 0)
-        return finish({-1, "version-not-newer"});
-    // Installation is deliberately delegated to a fixed system unit.  dpkg
-    // must not remain in APPLaunch.service's cgroup because postinst restarts
-    // APPLaunch and would otherwise terminate its own package transaction.
-    if (run({"systemctl", "start", "--no-block", "applaunch-updater.service"}) != 0)
-        return finish({-1, "submit"});
-    return finish({0, "submitted"});
+    return {code, code == 0 ? "completed" : "service"};
 }
 
 } // namespace cp0::update

--- a/ext_components/cp0_lvgl/src/cp0_sudo_async.cpp
+++ b/ext_components/cp0_lvgl/src/cp0_sudo_async.cpp
@@ -886,7 +886,7 @@ extern "C" void init_sudo_signals(void)
                 if (started) started(-EINVAL, 0);
                 return;
             }
-            argv = {"systemctl", value == "1" ? "restart" : "stop", "adbd.service"};
+            argv = {cp0_file_path("adb_helper"), "set", value};
         } else if (command == "AdbAuthorize") {
             if (value.size() < 680 || value.size() > 2048 || value.find('\n') != std::string::npos ||
                 value.find('\r') != std::string::npos) {

--- a/ext_components/cp0_lvgl/tests/run_tests.sh
+++ b/ext_components/cp0_lvgl/tests/run_tests.sh
@@ -24,6 +24,10 @@ trap 'rm -f "$binary" "$esc_state_object"' EXIT HUP INT TERM
     -I"$root/src" "$root/tests/test_audio_runtime_lifecycle.cpp" -o "$binary"
 "$binary"
 
+"${CXX:-c++}" -std=c++17 -Wall -Wextra -Werror -pthread \
+    -I"$root/src" "$root/tests/test_audio_quiet_period_gate.cpp" -o "$binary"
+"$binary"
+
 "${CXX:-c++}" -std=c++17 -Wall -Wextra -Werror \
     -I"$root/include" "$root/tests/test_async_testable_utils.cpp" -o "$binary"
 "$binary"

--- a/ext_components/cp0_lvgl/tests/test_audio_quiet_period_gate.cpp
+++ b/ext_components/cp0_lvgl/tests/test_audio_quiet_period_gate.cpp
@@ -1,0 +1,38 @@
+#include "cp0_audio_quiet_period_gate.hpp"
+
+#include <cassert>
+#include <chrono>
+#include <future>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+int main()
+{
+    cp0::audio::QuietPeriodGate gate;
+    gate.request();
+
+    const auto started = std::chrono::steady_clock::now();
+    auto quiet = std::async(std::launch::async, [&gate] {
+        return gate.wait_until_quiet(80ms);
+    });
+    std::this_thread::sleep_for(40ms);
+    gate.request();
+
+    const std::uint64_t generation = quiet.get();
+    const auto elapsed = std::chrono::steady_clock::now() - started;
+    assert(elapsed >= 100ms);
+    assert(elapsed < 1s);
+    assert(gate.current(generation));
+
+    gate.request();
+    assert(!gate.current(generation));
+
+    cp0::audio::QuietPeriodGate stopped_gate;
+    auto stopped = std::async(std::launch::async, [&stopped_gate] {
+        return stopped_gate.wait_until_quiet(5s);
+    });
+    std::this_thread::sleep_for(20ms);
+    stopped_gate.stop();
+    assert(stopped.get() == 0);
+}

--- a/ext_components/cp0_lvgl/tests/test_config_service.cpp
+++ b/ext_components/cp0_lvgl/tests/test_config_service.cpp
@@ -57,6 +57,14 @@ int main()
     assert(call(service, {"Save"}) == std::make_pair(0, std::string("ok")));
     assert(saved.size() == 3);
     assert(saved[0] == std::make_pair(std::string("count"), std::string("17")));
+    assert(call(service, {"SetInt", "extport_usb", "1"}).first == 0);
+    assert(call(service, {"SetInt", "extport_5vout", "0"}).first == 0);
+    assert(call(service, {"Save"}) == std::make_pair(0, std::string("ok")));
+    assert(saved.size() == 5);
+    assert(saved[0] == std::make_pair(std::string("count"), std::string("17")));
+    assert(saved[2] == std::make_pair(std::string("label"), std::string("hello")));
+    assert(saved[3] == std::make_pair(std::string("extport_usb"), std::string("1")));
+    assert(saved[4] == std::make_pair(std::string("extport_5vout"), std::string("0")));
 
     save_result = -1;
     assert(call(service, {"Save"}) == std::make_pair(-1, std::string("save failed")));

--- a/ext_components/cp0_lvgl/tests/test_launcher_updater.cpp
+++ b/ext_components/cp0_lvgl/tests/test_launcher_updater.cpp
@@ -13,6 +13,7 @@ struct Fixture {
     std::string architecture = "arm64\n";
     std::string candidate = "1.2.0\n";
     std::string installed = "1.1.0\n";
+    std::string state = "succeeded:1.2.0\n";
     std::string fail_operation;
 
     int run(const std::vector<std::string> &arguments)
@@ -25,7 +26,7 @@ struct Fixture {
 
     int capture(const std::vector<std::string> &arguments, std::string &output)
     {
-        if (arguments[0] == "cat") output = hash + "  applaunch_arm64.deb\n";
+        if (arguments[0] == "cat") output = state;
         else if (arguments[0] == "sha256sum") output = actual;
         else if (arguments[0] == "dpkg-query") output = installed;
         else if (arguments.size() >= 4 && arguments[3] == "Package") output = package;
@@ -54,29 +55,14 @@ int main()
 
     Fixture fixture;
     auto result = execute(fixture);
-    assert(result.code == 0 && result.stage == "submitted");
-
-    fixture.actual = std::string(64, 'b');
-    result = execute(fixture);
-    assert(result.code != 0 && result.stage == "checksum");
-    fixture.actual = std::string(64, 'a');
-
-    fixture.package = "other\n";
-    result = execute(fixture);
-    assert(result.stage == "package-name");
-    fixture.package = "applaunch\n";
-
-    fixture.architecture = "amd64\n";
-    result = execute(fixture);
-    assert(result.stage == "architecture");
-    fixture.architecture = "arm64\n";
-
-    fixture.fail_operation = "dpkg:--compare-versions";
-    result = execute(fixture);
-    assert(result.stage == "version-not-newer");
-    fixture.fail_operation.clear();
+    assert(result.code == 0 && result.stage == "1.2.0");
 
     fixture.fail_operation = "systemctl";
+    fixture.state = "failed:incompatible\n";
     result = execute(fixture);
-    assert(result.stage == "submit");
+    assert(result.code == 9 && result.stage == "incompatible");
+
+    fixture.state = "unreadable\n";
+    result = execute(fixture);
+    assert(result.code == 9 && result.stage == "service");
 }

--- a/ext_components/cp0_lvgl/tests/test_settings_policy.cpp
+++ b/ext_components/cp0_lvgl/tests/test_settings_policy.cpp
@@ -50,6 +50,8 @@ int main()
     assert(!cp0::settings::parse_integer_response("-1", 0, INT_MAX, parsed));
     assert(cp0::settings::parse_integer_file_line("12\n", 0, 100, parsed) && parsed == 12);
     assert(cp0::settings::parse_integer_file_line("12\r\n", 0, 100, parsed) && parsed == 12);
+    assert(cp0::settings::parse_integer_file_line("255\n", 0, INT_MAX, parsed) &&
+           cp0::settings::switch_value(parsed) == 1);
     assert(!cp0::settings::parse_integer_file_line("12junk\n", 0, 100, parsed));
     assert(cp0::settings::parse_switch_response("0", parsed) && parsed == 0);
     assert(cp0::settings::parse_switch_response("1", parsed) && parsed == 1);

--- a/projects/APPLaunch/APPLaunch/adb/cardputer-adb
+++ b/projects/APPLaunch/APPLaunch/adb/cardputer-adb
@@ -24,6 +24,9 @@ set -e
 
 SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 GADGET="$SELF_DIR/cardputer-adb-gadget"
+HOTPLUG="$SELF_DIR/cardputer-adb-hotplug"
+HOTPLUG_UNIT_NAME=cardputer-adb-hotplug.service
+HOTPLUG_UNIT=/etc/systemd/system/$HOTPLUG_UNIT_NAME
 ADB_KEYS=/adb_keys
 # Tests run this helper without privileges. Root executions always use the
 # production path, regardless of inherited environment variables.
@@ -172,6 +175,27 @@ ExecStartPost=
 ExecStartPost=$GADGET activate
 ExecStopPost=
 ExecStopPost=$GADGET reset
+Restart=on-failure
+RestartSec=1
+EOF
+    systemctl daemon-reload 2>/dev/null || true
+}
+
+install_hotplug_unit() {
+    [ -x "$HOTPLUG" ] || die "missing ADB hotplug monitor: $HOTPLUG"
+    cat > "$HOTPLUG_UNIT" <<EOF
+[Unit]
+Description=Recover CardputerZero ADB after USB reconnect
+After=adbd.service
+
+[Service]
+Type=simple
+ExecStart=$HOTPLUG
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target
 EOF
     systemctl daemon-reload 2>/dev/null || true
 }
@@ -229,32 +253,38 @@ stop_serial_gadget() {
 }
 
 cmd_enable() {
+    authorization_mode=${1:-paired}
     prepare_authorizations
-    [ "$(authorization_count)" -gt 0 ] || {
+    [ "$authorization_mode" = ui ] || [ "$(authorization_count)" -gt 0 ] || {
         log "pair a host in Settings before enabling ADB"
-        exit 11
+        return 11
     }
     ensure_adbd_installed
     setup_better_shell
     install_dropin
+    install_hotplug_unit
     stop_serial_gadget
 
     rc=0
     ensure_peripheral || rc=$?
     if [ "$rc" = 10 ]; then
         systemctl enable adbd.service 2>/dev/null || true
+        systemctl enable "$HOTPLUG_UNIT_NAME" 2>/dev/null || true
         log "USB switched to peripheral mode; reboot required"
-        exit 10
+        return 10
     fi
 
     systemctl enable adbd.service 2>/dev/null || true
     # restart (not just start) so the branded-gadget drop-in is applied even when
     # adbd was already running.
     systemctl restart adbd.service || die "failed to start adbd"
+    systemctl enable "$HOTPLUG_UNIT_NAME" 2>/dev/null || true
+    systemctl restart "$HOTPLUG_UNIT_NAME" || die "failed to start ADB hotplug monitor"
     log "ADB debug enabled"
 }
 
 cmd_disable() {
+    systemctl disable --now "$HOTPLUG_UNIT_NAME" 2>/dev/null || true
     systemctl disable --now adbd.service 2>/dev/null || true
     "$GADGET" reset 2>/dev/null || true
 
@@ -263,9 +293,23 @@ cmd_disable() {
     ensure_host || rc=$?
     if [ "$rc" = 10 ]; then
         log "ADB disabled; USB returns to host/hub mode after reboot"
-        exit 10
+        return 10
     fi
     log "ADB debug disabled"
+}
+
+# The Settings UI treats exit 10 as an applied setting that needs a reboot.
+# Other failures, including missing authorization (11), still reach the UI.
+cmd_set() {
+    value=$1
+    rc=0
+    case "$value" in
+        1) cmd_enable ui || rc=$? ;;
+        0) cmd_disable || rc=$? ;;
+        *) die "usage: cardputer-adb set <0|1>" ;;
+    esac
+    [ "$rc" -eq 10 ] && return 0
+    return "$rc"
 }
 
 cmd_status() {
@@ -323,6 +367,13 @@ cmd_migrate() {
     if [ "$before" -gt 0 ] && systemctl is-active --quiet adbd.service 2>/dev/null; then
         systemctl restart adbd.service || die "removed legacy key but failed to restart adbd"
     fi
+    if systemctl is-enabled --quiet adbd.service 2>/dev/null; then
+        install_hotplug_unit
+        systemctl enable "$HOTPLUG_UNIT_NAME" 2>/dev/null || true
+        if systemctl is-active --quiet adbd.service 2>/dev/null; then
+            systemctl restart "$HOTPLUG_UNIT_NAME" 2>/dev/null || true
+        fi
+    fi
 }
 
 cmd_clear_authorizations() {
@@ -336,10 +387,11 @@ cmd_clear_authorizations() {
 case "$1" in
     enable)    cmd_enable ;;
     disable)   cmd_disable ;;
+    set)       shift; cmd_set "${1:-}" ;;
     status)    cmd_status ;;
     authorize) shift; cmd_authorize "$@" ;;
     revoke) shift; cmd_revoke "$@" ;;
     migrate) cmd_migrate ;;
     clear-authorizations) cmd_clear_authorizations ;;
-    *) echo "Usage: $0 {enable|disable|status|authorize <pubkey>|revoke <fingerprint>|clear-authorizations|migrate}" >&2; exit 1 ;;
+    *) echo "Usage: $0 {enable|disable|set <0|1>|status|authorize <pubkey>|revoke <fingerprint>|clear-authorizations|migrate}" >&2; exit 1 ;;
 esac

--- a/projects/APPLaunch/main/ui/launcher_media_controls.cpp
+++ b/projects/APPLaunch/main/ui/launcher_media_controls.cpp
@@ -56,6 +56,20 @@ int read_volume()
     return LauncherMediaControlsModel::clamp_percent(volume);
 }
 
+bool read_mute()
+{
+    bool muted = model.muted();
+    cp0_signal_audio_api({"MuteRead"}, [&](int code, std::string data) {
+        int parsed = 0;
+        if (code == 0 && LauncherMediaControlsModel::parse_int(data, parsed) &&
+            (parsed == 0 || parsed == 1)) {
+            muted = parsed != 0;
+            model.set_mute(muted);
+        }
+    });
+    return muted;
+}
+
 int write_volume(int previous, int percent)
 {
     percent = LauncherMediaControlsModel::clamp_percent(percent);
@@ -129,6 +143,8 @@ namespace launcher_media_controls {
 
 int adjust_volume(int delta_percent)
 {
+    if (read_mute())
+        (void)toggle_mute();
     const int current = model.has_volume() ? model.volume_or(0) : read_volume();
     return write_volume(current, current + delta_percent);
 }

--- a/projects/APPLaunch/main/ui/model/adb_state.cpp
+++ b/projects/APPLaunch/main/ui/model/adb_state.cpp
@@ -97,6 +97,6 @@ std::vector<AdbAuthorization> parse_adb_authorizations(const char *output)
 
 bool adb_state_after_failure(const AdbStatus &status, bool previous)
 {
-    return status.valid ? status.active : previous;
+    return status.valid ? status.enabled : previous;
 }
 } // namespace setting

--- a/projects/APPLaunch/main/ui/model/st_key_encoder.cpp
+++ b/projects/APPLaunch/main/ui/model/st_key_encoder.cpp
@@ -7,6 +7,7 @@
 #include "st_key_encoder.hpp"
 
 #include "input_keys.h"
+#include "keyboard_input.h"
 
 #include <cstring>
 
@@ -28,4 +29,17 @@ std::string STKeyEncoder::encode(uint32_t evdev_key, const char *utf8,
     const size_t length = std::strlen(utf8);
     if (length == 0 || length > MAX_TEXT_BYTES) return {};
     return std::string(utf8, length);
+}
+
+int STKeyEncoder::scrollback_direction(uint32_t evdev_key, uint32_t modifiers,
+                                       bool shift_down)
+{
+    const bool shift = shift_down || (modifiers & KBD_MOD_SHIFT) != 0;
+    constexpr uint32_t LEGACY_MODIFIERS = KBD_MOD_CTRL | KBD_MOD_ALT;
+    const bool ctrl_alt = (modifiers & LEGACY_MODIFIERS) == LEGACY_MODIFIERS;
+    if (!shift && !ctrl_alt) return 0;
+
+    if (evdev_key == KEY_PAGEUP) return 1;
+    if (evdev_key == KEY_PAGEDOWN) return -1;
+    return 0;
 }

--- a/projects/APPLaunch/main/ui/model/st_key_encoder.hpp
+++ b/projects/APPLaunch/main/ui/model/st_key_encoder.hpp
@@ -17,4 +17,6 @@ public:
 
     static std::string encode(uint32_t evdev_key, const char *utf8,
                               bool application_cursor_mode);
+    static int scrollback_direction(uint32_t evdev_key, uint32_t modifiers,
+                                    bool shift_down);
 };

--- a/projects/APPLaunch/main/ui/model/system_page_model.cpp
+++ b/projects/APPLaunch/main/ui/model/system_page_model.cpp
@@ -56,10 +56,13 @@ const char *update_request(UpdateAction action)
 std::string update_job_label(UpdateAction action, int result_code,
                              const std::string &state)
 {
-    if (state == "running") return {};
+    if (state == "running")
+        return action == UpdateAction::CheckSystem
+            ? "Refreshing package lists..."
+            : "Checking launcher update...\nLauncher may restart";
     if (action == UpdateAction::CheckSystem)
         return result_code == 0 && state.rfind("succeeded:", 0) == 0
-            ? "System check complete" : "System check failed";
+            ? "Package lists refreshed" : "System check failed";
 
     if (result_code == 0 && state.rfind("succeeded:", 0) == 0)
         return "Launcher updated";

--- a/projects/APPLaunch/main/ui/model/system_page_model.cpp
+++ b/projects/APPLaunch/main/ui/model/system_page_model.cpp
@@ -53,6 +53,40 @@ const char *update_request(UpdateAction action)
     return "";
 }
 
+std::string update_job_label(UpdateAction action, int result_code,
+                             const std::string &state)
+{
+    if (state == "running") return {};
+    if (action == UpdateAction::CheckSystem)
+        return result_code == 0 && state.rfind("succeeded:", 0) == 0
+            ? "System check complete" : "System check failed";
+
+    if (result_code == 0 && state.rfind("succeeded:", 0) == 0)
+        return "Launcher updated";
+    if (state.rfind("failed:", 0) == 0) {
+        std::string stage = state.substr(7);
+        const size_t detail = stage.find(':');
+        if (detail != std::string::npos) stage.resize(detail);
+        if (stage == "incompatible") return "No compatible update";
+        if (stage == "version-not-newer") return "Launcher is up to date";
+        if (stage == "download-package" || stage == "download-checksum")
+            return "Update download failed";
+        if (stage == "checksum" || stage == "checksum-manifest")
+            return "Update verification failed";
+        if (stage == "rollback-unavailable") return "Update blocked: no rollback";
+    }
+    return "Launcher update failed";
+}
+
+std::string launcher_state_label(const std::string &state)
+{
+    if (state.empty()) return {};
+    if (state.rfind("succeeded:", 0) == 0) return "Launcher is up to date";
+    if (state.rfind("failed:", 0) == 0)
+        return update_job_label(UpdateAction::UpdateLauncher, -1, state);
+    return "Updating: " + state;
+}
+
 bool extport_toggle_value(bool previous, bool desired, bool gpio_succeeded)
 {
     return gpio_succeeded ? desired : previous;

--- a/projects/APPLaunch/main/ui/model/system_page_model.hpp
+++ b/projects/APPLaunch/main/ui/model/system_page_model.hpp
@@ -38,6 +38,9 @@ std::string version_label(const std::string &version);
 std::string build_label(const std::string &date, const std::string &channel,
                         const std::string &commit);
 const char *update_request(UpdateAction action);
+std::string update_job_label(UpdateAction action, int result_code,
+                             const std::string &state);
+std::string launcher_state_label(const std::string &state);
 bool extport_toggle_value(bool previous, bool desired, bool gpio_succeeded);
 
 } // namespace system_page

--- a/projects/APPLaunch/main/ui/page_app/setting/menu_builder.cpp
+++ b/projects/APPLaunch/main/ui/page_app/setting/menu_builder.cpp
@@ -20,7 +20,6 @@ void build_menu(UISetupPage &page)
     Help::append(page, candidate);
     ExtPort::append(page, candidate);
     access.developer().append(page, candidate);
-    access.rtc().append(page, candidate);
     access.bluetooth().append(page, candidate);
     Ethernet::append(page, candidate);
     Account::append(page, candidate);

--- a/projects/APPLaunch/main/ui/page_app/setting/system.cpp
+++ b/projects/APPLaunch/main/ui/page_app/setting/system.cpp
@@ -19,8 +19,16 @@ void apply_extport_toggle(UISetupPage &page,
     const bool desired = item.toggle_state;
     const int current = access.gpio_get(gpio_name);
     const bool previous = current >= 0 ? current != 0 : !desired;
+    const int previous_config = access.config_get_int(gpio_name, previous ? 1 : 0);
     const bool gpio_succeeded = access.gpio_set(gpio_name, desired ? 1 : 0);
-    item.toggle_state = system_page::extport_toggle_value(previous, desired, gpio_succeeded);
+    const bool config_succeeded = gpio_succeeded &&
+        access.config_set_int(gpio_name, desired ? 1 : 0) && access.config_save();
+    if (gpio_succeeded && !config_succeeded) {
+        access.config_set_int(gpio_name, previous_config != 0 ? 1 : 0);
+        access.gpio_set(gpio_name, previous ? 1 : 0);
+    }
+    item.toggle_state = system_page::extport_toggle_value(
+        previous, desired, gpio_succeeded && config_succeeded);
 }
 
 } // namespace
@@ -145,14 +153,14 @@ void ExtPort::append(UISetupPage &page, std::vector<MenuItem> &menu)
     MenuItem item;
     item.label = "ExtPort";
     SetupPageAccess access(page);
-    bool usb_enabled = access.gpio_get("GROVE5V") == 1;
-    bool output_enabled = access.gpio_get("EXT5V") == 1;
+    bool usb_enabled = access.gpio_get("extport_usb") == 1;
+    bool output_enabled = access.gpio_get("extport_5vout") == 1;
     item.sub_items = {
         {"GROVE5V", true, usb_enabled, [page_ptr]() {
-            apply_extport_toggle(*page_ptr, 0, "GROVE5V");
+            apply_extport_toggle(*page_ptr, 0, "extport_usb");
         }},
         {"EXT5V", true, output_enabled, [page_ptr]() {
-            apply_extport_toggle(*page_ptr, 1, "EXT5V");
+            apply_extport_toggle(*page_ptr, 1, "extport_5vout");
         }},
     };
     menu.push_back(item);
@@ -250,12 +258,9 @@ void Update::refresh_version_info(UISetupPage &page)
     MenuItem *item = SetupPageAccess(page).find_menu("Update");
     if (item && item->sub_items.size() >= 4) {
         cp0_signal_osinfo_api({"UpdateLauncherState"}, [&](int code, std::string state) {
-            if (code == 0 && state.rfind("failed:", 0) == 0)
-                item->sub_items[1].label = "Update " + state.substr(7);
-            else if (code == 0 && state.rfind("succeeded:", 0) == 0)
-                item->sub_items[1].label = "Launcher is up to date";
-            else if (code == 0 && !state.empty())
-                item->sub_items[1].label = "Updating: " + state;
+            if (code != 0) return;
+            const std::string label = system_page::launcher_state_label(state);
+            if (!label.empty()) item->sub_items[1].label = label;
         });
         item->sub_items[2].label = system_page::version_label(LAUNCHER_VERSION);
         item->sub_items[3].label = system_page::build_label(
@@ -292,11 +297,17 @@ void UISetupPage::start_update_job(const char *command, int item_index)
     if (!menu || item_index < 0 || item_index >= static_cast<int>(menu->sub_items.size())) return;
     menu->sub_items[item_index].label = item_index == 0 ? "Checking System..." : "Updating Launcher...";
     build_sub_view();
-    cp0_signal_osinfo_api({command}, [&](int code, std::string id) {
-        if (code == 0 && !id.empty()) update_job_id_ = std::move(id);
-    });
+    lv_refr_now(nullptr);
+    try {
+        cp0_signal_osinfo_api({command}, [&](int code, std::string id) {
+            if (code == 0 && !id.empty()) update_job_id_ = std::move(id);
+        });
+    } catch (...) {
+        update_job_id_.clear();
+    }
     if (update_job_id_.empty()) {
-        menu->sub_items[item_index].label = "Update start failed";
+        menu->sub_items[item_index].label = item_index == 0
+            ? "System check unavailable" : "Launcher update unavailable";
         build_sub_view();
         return;
     }
@@ -322,11 +333,11 @@ void UISetupPage::update_timer_cb(lv_timer_t *timer) noexcept
         MenuItem *menu = setting::SetupPageAccess(*page).find_menu("Update");
         if (menu && page->update_item_index_ >= 0 &&
             page->update_item_index_ < static_cast<int>(menu->sub_items.size())) {
+            const auto action = page->update_item_index_ == 0
+                ? system_page::UpdateAction::CheckSystem
+                : system_page::UpdateAction::UpdateLauncher;
             menu->sub_items[page->update_item_index_].label =
-                code == 0 && state == "succeeded:submitted" ? "Update submitted; restarting" :
-                (code == 0 && state.rfind("succeeded:", 0) == 0 ? "Update succeeded" :
-                (state.rfind("failed:", 0) == 0 ? "Update " + state.substr(7) :
-                                                  "Update status failed"));
+                system_page::update_job_label(action, code, state);
         }
         page->stop_update_timer(false);
         if (page->view_state_ == ViewState::SUB) page->build_sub_view();

--- a/projects/APPLaunch/main/ui/page_app/setting/system.cpp
+++ b/projects/APPLaunch/main/ui/page_app/setting/system.cpp
@@ -1,5 +1,6 @@
 #define APP_PAGE_IMPLEMENTATION_UNIT
 #include "../ui_app_setup.hpp"
+#include "../../launcher_toast.h"
 #include "../../model/system_page_model.hpp"
 #include "setup_page_access.hpp"
 
@@ -282,12 +283,14 @@ void Update::update_launcher(UISetupPage &page)
 
 void UISetupPage::stop_update_timer(bool cancel_job)
 {
+    const bool had_job = update_timer_ || !update_job_id_.empty();
     if (update_timer_) lv_timer_delete(update_timer_);
     update_timer_ = nullptr;
     if (cancel_job && !update_job_id_.empty())
         cp0_signal_osinfo_api({"UpdateJobCancel", update_job_id_}, nullptr);
     update_job_id_.clear();
     update_item_index_ = -1;
+    if (had_job) launcher_toast().hide();
 }
 
 void UISetupPage::start_update_job(const char *command, int item_index)
@@ -295,8 +298,11 @@ void UISetupPage::start_update_job(const char *command, int item_index)
     if (update_timer_ || !command) return;
     MenuItem *menu = setting::SetupPageAccess(*this).find_menu("Update");
     if (!menu || item_index < 0 || item_index >= static_cast<int>(menu->sub_items.size())) return;
-    menu->sub_items[item_index].label = item_index == 0 ? "Checking System..." : "Updating Launcher...";
-    build_sub_view();
+    const auto action = item_index == 0
+        ? system_page::UpdateAction::CheckSystem
+        : system_page::UpdateAction::UpdateLauncher;
+    const std::string running_label = system_page::update_job_label(action, 0, "running");
+    launcher_toast().show_persistent(running_label.c_str());
     lv_refr_now(nullptr);
     try {
         cp0_signal_osinfo_api({command}, [&](int code, std::string id) {
@@ -306,17 +312,15 @@ void UISetupPage::start_update_job(const char *command, int item_index)
         update_job_id_.clear();
     }
     if (update_job_id_.empty()) {
-        menu->sub_items[item_index].label = item_index == 0
-            ? "System check unavailable" : "Launcher update unavailable";
-        build_sub_view();
+        launcher_toast().show(item_index == 0
+            ? "System check unavailable" : "Launcher update unavailable");
         return;
     }
     update_item_index_ = item_index;
     update_timer_ = lv_timer_create(update_timer_cb, 500, this);
     if (!update_timer_) {
-        menu->sub_items[item_index].label = "Status unavailable";
         stop_update_timer();
-        build_sub_view();
+        launcher_toast().show("Update status unavailable");
     }
 }
 
@@ -330,18 +334,15 @@ void UISetupPage::update_timer_cb(lv_timer_t *timer) noexcept
         cp0_signal_osinfo_api({"UpdateJobStatus", page->update_job_id_},
             [&](int result, std::string payload) { code = result; state = std::move(payload); });
         if (code == 0 && state == "running") return;
-        MenuItem *menu = setting::SetupPageAccess(*page).find_menu("Update");
-        if (menu && page->update_item_index_ >= 0 &&
-            page->update_item_index_ < static_cast<int>(menu->sub_items.size())) {
-            const auto action = page->update_item_index_ == 0
-                ? system_page::UpdateAction::CheckSystem
-                : system_page::UpdateAction::UpdateLauncher;
-            menu->sub_items[page->update_item_index_].label =
-                system_page::update_job_label(action, code, state);
-        }
+        const auto action = page->update_item_index_ == 0
+            ? system_page::UpdateAction::CheckSystem
+            : system_page::UpdateAction::UpdateLauncher;
+        const std::string result_label =
+            system_page::update_job_label(action, code, state);
         page->stop_update_timer(false);
-        if (page->view_state_ == ViewState::SUB) page->build_sub_view();
+        launcher_toast().show(result_label.c_str());
     } catch (...) {
         page->stop_update_timer();
+        launcher_toast().show("Update status unavailable");
     }
 }

--- a/projects/APPLaunch/main/ui/page_app/ui_app_setup.cpp
+++ b/projects/APPLaunch/main/ui/page_app/ui_app_setup.cpp
@@ -36,7 +36,7 @@ void UISetupPage::play_enter()
 
 void UISetupPage::play_back()
 {
-    play_audio_file(snd_back_);
+    cp0_signal_audio_api({"SystemSoundPlay", "1"}, nullptr);
 }
 
 void UISetupPage::schedule_volume_preview()

--- a/projects/APPLaunch/main/ui/page_app/ui_app_st_renderer.cpp
+++ b/projects/APPLaunch/main/ui/page_app/ui_app_st_renderer.cpp
@@ -6,6 +6,7 @@
 
 #define APP_PAGE_IMPLEMENTATION_UNIT
 #include "ui_app_st.hpp"
+#include "../model/st_key_encoder.hpp"
 
 void UISTPage::create_ui()
 {
@@ -284,14 +285,10 @@ void UISTPage::event_cb(lv_event_t *event)
         }
     }
 
-    bool shift = shift_down_ || (key->mods & KBD_MOD_SHIFT) != 0;
-    if (key->key_state && shift && key->key_code == KEY_PAGEUP) {
-        scrollback_page(1);
-        render_all();
-        return;
-    }
-    if (key->key_state && shift && key->key_code == KEY_PAGEDOWN) {
-        scrollback_page(-1);
+    const int scrollback_direction = STKeyEncoder::scrollback_direction(
+        key->key_code, key->mods, shift_down_);
+    if (key->key_state && scrollback_direction != 0) {
+        scrollback_page(scrollback_direction);
         render_all();
         return;
     }

--- a/projects/APPLaunch/tests/run_tests.sh
+++ b/projects/APPLaunch/tests/run_tests.sh
@@ -195,6 +195,15 @@ ${CXX:-g++} -std=c++17 -Wall -Wextra -Werror \
 
 ${CXX:-g++} -std=c++17 -Wall -Wextra -Werror \
     -I"$(dirname "$0")/../../../ext_components/cp0_lvgl/include" \
+    -I"$(dirname "$0")/../../../SDK/github_source/eventpp/include" \
+    "$(dirname "$0")/test_launcher_media_controls.cpp" \
+    "$(dirname "$0")/../main/ui/launcher_media_controls.cpp" \
+    "$(dirname "$0")/../main/ui/model/launcher_media_model.cpp" \
+    -o "$build_dir/test_launcher_media_controls"
+"$build_dir/test_launcher_media_controls"
+
+${CXX:-g++} -std=c++17 -Wall -Wextra -Werror \
+    -I"$(dirname "$0")/../../../ext_components/cp0_lvgl/include" \
     "$(dirname "$0")/test_global_hint_policy.cpp" \
     "$(dirname "$0")/../main/ui/model/global_hint_policy.cpp" \
     -o "$build_dir/test_global_hint_policy"

--- a/projects/APPLaunch/tests/test_adb_packaging.py
+++ b/projects/APPLaunch/tests/test_adb_packaging.py
@@ -46,7 +46,8 @@ assert 'action.lookup("unit") == "applaunch-updater.service"' in policy
 assert 'action.lookup("verb") == "start"' in policy
 assert 'action.lookup("verb") == "stop"' in policy
 assert 'action.lookup("unit") == "applaunch-apt-update.service"' in policy
-assert "subject.local && subject.active" in policy
+assert 'subject.isInGroup("sudo")' in policy
+assert "subject.local && subject.active" not in policy
 
 service = packager._updater_service_text()
 assert "Type=oneshot" in service

--- a/projects/APPLaunch/tests/test_adb_state.cpp
+++ b/projects/APPLaunch/tests/test_adb_state.cpp
@@ -14,8 +14,10 @@ int main()
     assert(!parse_adb_status("unrelated=active\n").valid);
     assert(!parse_adb_status(nullptr).valid);
     assert(adb_state_after_failure(active, false));
-    assert(!adb_state_after_failure(pending, true));
+    assert(adb_state_after_failure(pending, false));
     assert(!adb_state_after_failure(off, true));
+    AdbStatus transient = parse_adb_status("adbd=active\nenabled=disabled\n");
+    assert(!adb_state_after_failure(transient, true));
     assert(adb_state_after_failure(AdbStatus{}, true));
     assert(!adb_state_after_failure(AdbStatus{}, false));
     AdbStatus paired = parse_adb_status("adbd=inactive\nenabled=disabled\nauthorizations=2\n");

--- a/projects/APPLaunch/tests/test_cardputer_adb.sh
+++ b/projects/APPLaunch/tests/test_cardputer_adb.sh
@@ -2,8 +2,10 @@
 set -eu
 
 helper=$(dirname "$0")/../APPLaunch/adb/cardputer-adb
+hotplug_source=$(dirname "$0")/../../../scripts/cardputer_adb_hotplug.c
 test_dir=$(mktemp -d)
 trap 'rm -rf "$test_dir"' EXIT
+hotplug="$test_dir/cardputer-adb-hotplug"
 keys="$test_dir/adb_keys"
 mkdir -p "$test_dir/root" "$test_dir/bin"
 cat > "$test_dir/bin/systemctl" <<'EOF'
@@ -11,12 +13,17 @@ cat > "$test_dir/bin/systemctl" <<'EOF'
 echo "$*" >> "$CARDPUTER_ADB_TEST_ROOT/systemctl.log"
 case "$1 $2" in
     "is-active --quiet") [ "${MOCK_ADBD_ACTIVE:-0}" = 1 ] ;;
+    "is-enabled --quiet")
+        [ "${MOCK_ADBD_ENABLED:-0}" = 1 ] &&
+            [ ! -e "$CARDPUTER_ADB_TEST_ROOT/hotplug.stop" ]
+        ;;
     *) exit 0 ;;
 esac
 EOF
 chmod +x "$test_dir/bin/systemctl"
 PATH="$test_dir/bin:$PATH"
 export PATH
+${CC:-cc} -std=c11 -O2 -Wall -Wextra -Werror "$hotplug_source" -o "$hotplug"
 key_bin="$test_dir/key.bin"
 printf '\100\000\000\000' > "$key_bin"
 dd if=/dev/zero bs=1 count=516 >> "$key_bin" 2>/dev/null
@@ -68,3 +75,23 @@ grep -q '^restart adbd.service$' "$test_dir/root/systemctl.log"
 
 # Root executions must ignore all test-path environment overrides.
 grep -q '\[ "$(id -u)" -ne 0 \]' "$helper"
+# The product UI remains usable while its pairing views are intentionally hidden.
+grep -q 'cmd_enable ui' "$helper"
+
+# Reconnecting a previously detached UDC restarts adbd exactly once.
+mkdir -p "$test_dir/root/sys/class/udc/mock"
+printf '%s\n' 'not attached' > "$test_dir/root/sys/class/udc/mock/state"
+: > "$test_dir/root/systemctl.log"
+env $test_env CARDPUTER_ADB_HOTPLUG_TIMEOUT_MS=100 "$hotplug" &
+hotplug_pid=$!
+sleep 0.2
+printf '%s\n' configured > "$test_dir/root/sys/class/udc/mock/state"
+tries=0
+while ! grep -q '^restart adbd.service$' "$test_dir/root/systemctl.log"; do
+    tries=$((tries + 1))
+    [ "$tries" -lt 30 ] || { kill "$hotplug_pid"; exit 1; }
+    sleep 0.1
+done
+kill "$hotplug_pid"
+wait "$hotplug_pid" || true
+[ "$(grep -c '^restart adbd.service$' "$test_dir/root/systemctl.log")" -eq 1 ]

--- a/projects/APPLaunch/tests/test_launcher_media_controls.cpp
+++ b/projects/APPLaunch/tests/test_launcher_media_controls.cpp
@@ -1,0 +1,104 @@
+#include "../main/ui/launcher_media_controls.h"
+
+#include "hal_lvgl_bsp.h"
+
+#include <cassert>
+#include <functional>
+#include <iterator>
+#include <list>
+#include <string>
+#include <vector>
+
+eventpp::CallbackList<void(std::list<std::string>, std::function<void(int, std::string)>)>
+    cp0_signal_audio_api;
+eventpp::CallbackList<void(std::list<std::string>, std::function<void(int, std::string)>)>
+    cp0_signal_config_api;
+eventpp::CallbackList<void(std::list<std::string>, std::function<void(int, std::string)>)>
+    cp0_signal_settings_api;
+
+namespace {
+
+int sink_volume = 80;
+int configured_volume = 80;
+bool sink_muted = true;
+int mute_toggles = 0;
+std::vector<std::string> audio_commands;
+
+void reply(const std::function<void(int, std::string)> &callback,
+           int code, const std::string &data)
+{
+    if (callback)
+        callback(code, data);
+}
+
+} // namespace
+
+int main()
+{
+    cp0_signal_audio_api.append(
+        [](std::list<std::string> arguments,
+           std::function<void(int, std::string)> callback) {
+            assert(!arguments.empty());
+            const std::string command = arguments.front();
+            audio_commands.push_back(command);
+
+            if (command == "MuteRead") {
+                reply(callback, 0, sink_muted ? "1" : "0");
+            } else if (command == "MuteToggle") {
+                sink_muted = !sink_muted;
+                ++mute_toggles;
+                reply(callback, 0, sink_muted ? "1" : "0");
+            } else if (command == "VolumeRead") {
+                reply(callback, 0, std::to_string(sink_volume));
+            } else if (command == "VolumeWrite") {
+                assert(arguments.size() == 2);
+                sink_volume = std::stoi(*std::next(arguments.begin()));
+                reply(callback, 0, std::to_string(sink_volume));
+            } else {
+                assert(false);
+            }
+        });
+
+    cp0_signal_config_api.append(
+        [](std::list<std::string> arguments,
+           std::function<void(int, std::string)> callback) {
+            assert(!arguments.empty());
+            const std::string command = arguments.front();
+            if (command == "GetInt") {
+                reply(callback, 0, std::to_string(configured_volume));
+            } else if (command == "SetInt") {
+                assert(arguments.size() == 3);
+                configured_volume = std::stoi(*std::next(arguments.begin(), 2));
+                reply(callback, 0, "");
+            } else if (command == "Save") {
+                reply(callback, 0, "");
+            } else {
+                assert(false);
+            }
+        });
+
+    assert(launcher_media_controls::adjust_volume(-5) == 75);
+    assert(!sink_muted);
+    assert(sink_volume == 75);
+    assert(configured_volume == 75);
+    assert(mute_toggles == 1);
+    assert(audio_commands.size() >= 4);
+    assert(audio_commands[0] == "MuteRead");
+    assert(audio_commands[1] == "MuteToggle");
+    assert(audio_commands[2] == "VolumeRead");
+    assert(audio_commands[3] == "VolumeWrite");
+
+    sink_muted = true;
+    assert(launcher_media_controls::adjust_volume(5) == 80);
+    assert(!sink_muted);
+    assert(sink_volume == 80);
+    assert(configured_volume == 80);
+    assert(mute_toggles == 2);
+
+    assert(launcher_media_controls::adjust_volume(-5) == 75);
+    assert(!sink_muted);
+    assert(sink_volume == 75);
+    assert(configured_volume == 75);
+    assert(mute_toggles == 2);
+    return 0;
+}

--- a/projects/APPLaunch/tests/test_st_key_encoder.cpp
+++ b/projects/APPLaunch/tests/test_st_key_encoder.cpp
@@ -8,6 +8,7 @@
 #include "../main/ui/model/st_page_contract.hpp"
 
 #include "input_keys.h"
+#include "keyboard_input.h"
 
 #include <cassert>
 #include <string>
@@ -65,5 +66,18 @@ int main()
 
     // A recognized control key never falls through to the supplied text.
     assert(STKeyEncoder::encode(KEY_ENTER, "ignored", false) == "\r");
+
+    assert(STKeyEncoder::scrollback_direction(KEY_PAGEUP, 0, false) == 0);
+    assert(STKeyEncoder::scrollback_direction(KEY_PAGEDOWN, KBD_MOD_CTRL, false) == 0);
+    assert(STKeyEncoder::scrollback_direction(KEY_PAGEDOWN, KBD_MOD_ALT, false) == 0);
+    assert(STKeyEncoder::scrollback_direction(KEY_PAGEUP, KBD_MOD_SHIFT, false) == 1);
+    assert(STKeyEncoder::scrollback_direction(KEY_PAGEDOWN, KBD_MOD_SHIFT, false) == -1);
+    assert(STKeyEncoder::scrollback_direction(KEY_PAGEUP, 0, true) == 1);
+    assert(STKeyEncoder::scrollback_direction(KEY_PAGEDOWN, 0, true) == -1);
+
+    constexpr uint32_t ctrl_alt = KBD_MOD_CTRL | KBD_MOD_ALT;
+    assert(STKeyEncoder::scrollback_direction(KEY_PAGEUP, ctrl_alt, false) == 1);
+    assert(STKeyEncoder::scrollback_direction(KEY_PAGEDOWN, ctrl_alt, false) == -1);
+    assert(STKeyEncoder::scrollback_direction(KEY_A, ctrl_alt, false) == 0);
     return 0;
 }

--- a/projects/APPLaunch/tests/test_system_page_model.cpp
+++ b/projects/APPLaunch/tests/test_system_page_model.cpp
@@ -38,9 +38,12 @@ int main()
     assert(std::string(update_request(UpdateAction::CheckSystem)) == "AptUpdateStart");
     assert(std::string(update_request(UpdateAction::UpdateLauncher)) ==
            "UpdateLauncherStart");
-    assert(update_job_label(UpdateAction::CheckSystem, 0, "running").empty());
+    assert(update_job_label(UpdateAction::CheckSystem, 0, "running") ==
+           "Refreshing package lists...");
+    assert(update_job_label(UpdateAction::UpdateLauncher, 0, "running") ==
+           "Checking launcher update...\nLauncher may restart");
     assert(update_job_label(UpdateAction::CheckSystem, 0, "succeeded:completed") ==
-           "System check complete");
+           "Package lists refreshed");
     assert(update_job_label(UpdateAction::CheckSystem, 1, "failed:apt-update:1") ==
            "System check failed");
     assert(update_job_label(UpdateAction::UpdateLauncher, 1,

--- a/projects/APPLaunch/tests/test_system_page_model.cpp
+++ b/projects/APPLaunch/tests/test_system_page_model.cpp
@@ -38,6 +38,20 @@ int main()
     assert(std::string(update_request(UpdateAction::CheckSystem)) == "AptUpdateStart");
     assert(std::string(update_request(UpdateAction::UpdateLauncher)) ==
            "UpdateLauncherStart");
+    assert(update_job_label(UpdateAction::CheckSystem, 0, "running").empty());
+    assert(update_job_label(UpdateAction::CheckSystem, 0, "succeeded:completed") ==
+           "System check complete");
+    assert(update_job_label(UpdateAction::CheckSystem, 1, "failed:apt-update:1") ==
+           "System check failed");
+    assert(update_job_label(UpdateAction::UpdateLauncher, 1,
+                            "failed:incompatible:1") == "No compatible update");
+    assert(update_job_label(UpdateAction::UpdateLauncher, 1,
+                            "failed:version-not-newer:1") == "Launcher is up to date");
+    assert(update_job_label(UpdateAction::UpdateLauncher, 1,
+                            "failed:download-package:1") == "Update download failed");
+    assert(launcher_state_label("downloading") == "Updating: downloading");
+    assert(launcher_state_label("succeeded:0.6.32") == "Launcher is up to date");
+    assert(launcher_state_label("failed:incompatible") == "No compatible update");
 
     assert(extport_toggle_value(false, true, true));
     assert(!extport_toggle_value(true, false, true));

--- a/projects/APPLaunch/tests/test_updater_packaging.py
+++ b/projects/APPLaunch/tests/test_updater_packaging.py
@@ -28,7 +28,8 @@ def run_update(fail_install: bool = False,
                keep_audit_dirty: bool = False,
                unhealthy_process: bool = False,
                audit_required: bool = False,
-               interrupted_candidate: bool = False) -> tuple[subprocess.CompletedProcess[str], str, str]:
+               interrupted_candidate: bool = False,
+               compatible: bool = True) -> tuple[subprocess.CompletedProcess[str], str, str]:
     with tempfile.TemporaryDirectory() as temp_dir:
         root = Path(temp_dir)
         fake_bin = root / "bin"
@@ -55,6 +56,9 @@ def run_update(fail_install: bool = False,
         (release / "applaunch_arm64.deb.sha256").write_text(
             f"{digest}  applaunch_arm64.deb\n", encoding="ascii"
         )
+        (release / "applaunch_arm64.deb.update-abi").write_text(
+            "1\n" if compatible else "0\n", encoding="ascii"
+        )
         if provide_rollback:
             old_package = old_release / "applaunch_1.0_arm64.deb"
             old_package.write_bytes(b"trusted previous package")
@@ -68,6 +72,7 @@ def run_update(fail_install: bool = False,
         executable(
             fake_bin / "dpkg-deb",
             'case "$3" in Package) echo applaunch;; Architecture) echo arm64;; '
+            'X-CardputerZero-Update-ABI) echo "${TEST_UPDATE_ABI:-1}";; '
             'Version) case "$2" in *installed.deb|*rollback.deb) echo 1.0;; *) echo 2.0;; esac;; esac\n',
         )
         executable(
@@ -113,6 +118,7 @@ def run_update(fail_install: bool = False,
                 "APPLAUNCH_UPDATE_EXECUTABLE": str(app_executable),
                 "APPLAUNCH_UPDATE_PROC_ROOT": str(proc),
                 "APPLAUNCH_UPDATE_HEALTH_CHECKS": "1",
+                "TEST_UPDATE_ABI": "1" if compatible else "0",
             }
         )
         if interrupted_candidate:
@@ -178,6 +184,34 @@ assert "dpkg --configure -a" in commands
 missing_rollback, status, commands = run_update(provide_rollback=False)
 assert missing_rollback.returncode != 0
 assert status == "failed:rollback-unavailable"
+
+incompatible, status, commands = run_update(compatible=False)
+assert incompatible.returncode != 0
+assert status == "failed:incompatible"
+assert "dpkg -i" not in commands
+assert "applaunch_arm64.deb" not in commands
+
+old_source_date_epoch = os.environ.get("SOURCE_DATE_EPOCH")
+try:
+    os.environ["SOURCE_DATE_EPOCH"] = "1704067200"
+    control = packager._control_text(packager.PackageConfig())
+    assert "Packaged-Date: 2024-01-01 00:00:00 UTC\n" in control
+    assert "X-CardputerZero-Update-ABI: 1\n" in control
+    other_control = packager._control_text(
+        packager.PackageConfig(app_name="OtherApp", package_name="other")
+    )
+    assert "X-CardputerZero-Update-ABI" not in other_control
+    assert packager._ar_member_header("data.tar.gz", 1)[16:28].strip() == b"1704067200"
+finally:
+    if old_source_date_epoch is None:
+        os.environ.pop("SOURCE_DATE_EPOCH", None)
+    else:
+        os.environ["SOURCE_DATE_EPOCH"] = old_source_date_epoch
+
+assert "/usr/share/APPLaunch/bin/M5CardputerZero-APPLaunch" in packager._updater_script_text()
+assert 'mktemp -d "$state_root/self.XXXXXX"' in packager._updater_script_text()
+assert "/run/applaunch-updater" not in packager._updater_script_text()
+assert "TimeoutStartSec=20min" in packager._updater_service_text()
 assert "dpkg -i" not in commands
 
 workflow = (repo / ".github" / "workflows" / "launcher-build.yml").read_text(
@@ -187,3 +221,11 @@ assert "branches: [master, ci/**]" in workflow
 assert "if: github.ref == 'refs/heads/master'" in workflow
 assert "startsWith(github.ref, 'refs/heads/ci/')" not in workflow
 assert workflow.count("tag_name: launcher-latest") == 1
+assert "scripts/build_cardputerzero_release_local.sh" in workflow
+assert "python3 scripts/debian_packager.py --version" not in workflow
+
+release_builder = (repo / "scripts" / "build_cardputerzero_release_local.sh").read_text(
+    encoding="utf-8"
+)
+assert 'CLEAN_BUILD=${CLEAN_BUILD:-1}' in release_builder
+assert '"$ROOT/projects/$project/main/build"' in release_builder

--- a/projects/LaunchWizard/main/ui/apply_checkpoint.cpp
+++ b/projects/LaunchWizard/main/ui/apply_checkpoint.cpp
@@ -201,9 +201,8 @@ bool ApplyCheckpointStore::clear(std::string &error) const
 std::uint64_t wizard_configuration_fingerprint(const WizardModel &model)
 {
     std::uint64_t hash = UINT64_C(14695981039346656037);
+    hash_string(hash, "oobe-no-manual-time-v1");
     hash_string(hash, model.current_timezone().name);
-    hash_string(hash, model.manual_date);
-    hash_string(hash, model.manual_time);
     hash_string(hash, model.hostname);
     hash_string(hash, model.username);
     hash_string(hash, model.password);

--- a/projects/LaunchWizard/main/ui/apply_checkpoint.h
+++ b/projects/LaunchWizard/main/ui/apply_checkpoint.h
@@ -10,7 +10,7 @@
 
 namespace launch_wizard {
 
-inline constexpr int kApplyStepCount = 9;
+inline constexpr int kApplyStepCount = 8;
 
 enum class ApplyCheckpointLoad {
     Missing,

--- a/projects/LaunchWizard/main/ui/wizard_model.h
+++ b/projects/LaunchWizard/main/ui/wizard_model.h
@@ -173,7 +173,7 @@ struct WizardModel {
     int exit_ticks = 0;
     std::string worker_message;
     int worker_step = 0;
-    int worker_total = 9;
+    int worker_total = 8;
     std::mutex mutex;
 
     const Timezone &current_timezone() const;

--- a/projects/LaunchWizard/main/ui/wizard_service.cpp
+++ b/projects/LaunchWizard/main/ui/wizard_service.cpp
@@ -664,7 +664,7 @@ std::string enable_applaunch_service(const std::string &user, unsigned int uid)
 }
 
 // ---------------------------------------------------------------------------
-// System integration -- new OOBE steps (timezone / hostname / wifi / time / ssh).
+// System integration -- OOBE steps (timezone / hostname / wifi / ssh).
 // ---------------------------------------------------------------------------
 std::string apply_timezone(const std::string &timezone)
 {
@@ -892,11 +892,6 @@ std::string WizardService::apply(
         best_effort("Setting timezone...", [timezone] {
             const std::string error = apply_timezone(timezone);
             return error.empty() ? error : "Timezone failed: " + error;
-        }),
-        best_effort("Setting date and time...", [&g] {
-            const std::string error = WizardService::set_manual_time(
-                g.manual_date, g.manual_time);
-            return error.empty() ? error : "System time failed: " + error;
         }),
         best_effort("Setting hostname...", [hostname] {
             const std::string error = apply_hostname(hostname);

--- a/projects/LaunchWizard/main/ui/wizard_view.cpp
+++ b/projects/LaunchWizard/main/ui/wizard_view.cpp
@@ -941,7 +941,11 @@ void handle_back()
                              : (g.use_ethernet ? Screen::EthernetConfig
                                                : Screen::WifiPassword));
         break;
-    case Screen::Ssh: go(Screen::ManualTime); break;
+    case Screen::Ssh:
+        go(g.network_skipped ? Screen::Network
+                             : (g.use_ethernet ? Screen::EthernetConfig
+                                               : Screen::WifiPassword));
+        break;
     case Screen::ApplyError: go(Screen::Ssh); break;
     case Screen::Applying: break;
     case Screen::RestartPrompt: break;
@@ -1088,7 +1092,7 @@ void handle_enter()
         } else {
             g.network_skipped = true;
             g.use_ethernet = false;
-            go(Screen::ManualTime);
+            go(Screen::Ssh);
         }
         break;
     case Screen::EthernetConfig:
@@ -1101,7 +1105,7 @@ void handle_enter()
                 render();
                 return;
             }
-            go(Screen::ManualTime);
+            go(Screen::Ssh);
         }
         break;
     case Screen::WifiList:
@@ -1122,7 +1126,7 @@ void handle_enter()
         break;
     case Screen::WifiPassword:
         if (g.wifi_connected) {
-            go(Screen::ManualTime);
+            go(Screen::Ssh);
         } else if (g.wifi_manual && g.wifi_focus == 0) {
             g.wifi_focus = 1;
             render();
@@ -1179,7 +1183,7 @@ void handle_tab()
             render();
             return;
         }
-        go(Screen::ManualTime);
+        go(Screen::Ssh);
         break;
     case Screen::WifiPassword:
         if (g.wifi_manual && !g.wifi_connecting && !g.wifi_connected) {

--- a/projects/LaunchWizard/tests/test_apply_checkpoint.cpp
+++ b/projects/LaunchWizard/tests/test_apply_checkpoint.cpp
@@ -58,6 +58,15 @@ bool test_apply_checkpoint()
     changed.hostname = "different-host";
     expect(wizard_configuration_fingerprint(changed) != fingerprint,
            "apply fingerprint did not include hostname");
+    WizardModel manual_time_changed;
+    manual_time_changed.password = configuration.password;
+    manual_time_changed.wifi_password = configuration.wifi_password;
+    manual_time_changed.manual_date = "2030-01-02";
+    manual_time_changed.manual_time = "03:04";
+    expect(wizard_configuration_fingerprint(manual_time_changed) == fingerprint,
+           "inactive manual time still affected the apply fingerprint");
+    expect(kApplyStepCount == 8,
+           "manual time removal did not reduce the apply sequence to eight steps");
 
     // A new invocation always starts from the first step, even when a valid
     // checkpoint from an interrupted configuration exists.

--- a/projects/ZClaw/main/ui/zclaw_fonts.cpp
+++ b/projects/ZClaw/main/ui/zclaw_fonts.cpp
@@ -29,6 +29,8 @@ std::string runtime_font_path()
 {
     const char *env_path = std::getenv("ZCLAW_FONT");
     const std::vector<std::string> candidates = {
+        "/usr/share/fonts/truetype/jetbrains-mono/JetBrainsMono-Regular.ttf",
+        "/usr/share/APPLaunch/share/font/LiberationMono-Regular.ttf",
         cp0_file_path("AlibabaPuHuiTi-3-55-Regular.ttf"),
         cp0_file_path("share/font/AlibabaPuHuiTi-3-55-Regular.ttf"),
         "./APPLaunch/share/font/AlibabaPuHuiTi-3-55-Regular.ttf",

--- a/scripts/build_cardputerzero_release_local.sh
+++ b/scripts/build_cardputerzero_release_local.sh
@@ -1,20 +1,55 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
-    echo "usage: $0 <debian-version> [revision]" >&2
-    echo "example: $0 0.6.29+local.audiofix5 1" >&2
+if [ "$#" -gt 2 ]; then
+    echo "usage: $0 [debian-version] [revision]" >&2
+    echo "example: $0 0.6.31+local.test1 1" >&2
     exit 2
 fi
 
-VERSION=$1
-REVISION=${2:-1}
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+
+derive_version() {
+    tag=$(git -C "$ROOT" describe --tags --match 'launcher-v[0-9]*' \
+        --abbrev=0 2>/dev/null || true)
+    base=${tag#launcher-v}
+    [ -n "$base" ] || base=0.0.0
+    head=$(git -C "$ROOT" rev-parse --short=12 HEAD)
+    if [ -z "$(git -C "$ROOT" status --porcelain=v1)" ]; then
+        if [ -n "$tag" ] && [ "$(git -C "$ROOT" rev-list --count "$tag"..HEAD)" -eq 0 ]; then
+            printf '%s\n' "$base"
+        else
+            printf '%s+git.%s\n' "$base" "$head"
+        fi
+        return
+    fi
+
+    fingerprint=$(
+        {
+            git -C "$ROOT" diff --binary HEAD
+            git -C "$ROOT" ls-files --others --exclude-standard -z |
+                LC_ALL=C sort -z |
+                while IFS= read -r -d '' file; do
+                    sha256sum -- "$ROOT/$file"
+                done
+        } | sha256sum | cut -c1-12
+    )
+    printf '%s+local.%s.w%s\n' "$base" "$head" "$fingerprint"
+}
+
+VERSION=${1:-$(derive_version)}
+REVISION=${2:-1}
 JOBS=${JOBS:-$(nproc)}
 OUTPUT_DIR=${OUTPUT_DIR:-"$ROOT/../build-artifacts/launcher-release"}
 SCONS=${SCONS:-scons}
+CLEAN_BUILD=${CLEAN_BUILD:-1}
 
-for command in aarch64-linux-gnu-g++ dpkg-deb python3; do
+case "$CLEAN_BUILD" in
+    0|1) ;;
+    *) echo "ERROR: CLEAN_BUILD must be 0 or 1" >&2; exit 2 ;;
+esac
+
+for command in aarch64-linux-gnu-gcc aarch64-linux-gnu-g++ dpkg-deb python3; do
     if ! command -v "$command" >/dev/null 2>&1; then
         echo "ERROR: required command not found: $command" >&2
         exit 1
@@ -42,6 +77,17 @@ export SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-$(git -C "$ROOT" show -s --format=
 
 build_project() {
     project=$1
+    case "$project" in
+        APPLaunch|AppStore|Calculator|LaunchWizard|ZClaw) ;;
+        *) echo "ERROR: unsupported project: $project" >&2; return 2 ;;
+    esac
+    if [ "$CLEAN_BUILD" = 1 ]; then
+        echo "=== Cleaning $project build outputs ==="
+        rm -rf -- \
+            "$ROOT/projects/$project/build" \
+            "$ROOT/projects/$project/dist" \
+            "$ROOT/projects/$project/main/build"
+    fi
     echo "=== Building $project for CardputerZero ARM64 ==="
     (
         cd "$ROOT/projects/$project"
@@ -71,6 +117,10 @@ cp -a "$ROOT/projects/ZClaw/dist/APPLaunch/." \
     "$ROOT/projects/APPLaunch/dist/APPLaunch/"
 install -D -m 0755 "$ROOT/projects/LaunchWizard/dist/LaunchWizard" \
     "$ROOT/projects/APPLaunch/dist/APPLaunch/bin/LaunchWizard"
+aarch64-linux-gnu-gcc -std=c11 -Os -s -Wall -Wextra -Werror \
+    "$ROOT/scripts/cardputer_adb_hotplug.c" \
+    -o "$ROOT/projects/APPLaunch/dist/APPLaunch/adb/cardputer-adb-hotplug"
+chmod 0755 "$ROOT/projects/APPLaunch/dist/APPLaunch/adb/cardputer-adb-hotplug"
 
 install -d "$OUTPUT_DIR"
 python3 "$ROOT/scripts/debian_packager.py" build \
@@ -96,3 +146,15 @@ echo "=== Release package ==="
 dpkg-deb -f "$PACKAGE" Package Version Architecture
 stat -c '%s %n' "$PACKAGE"
 sha256sum "$PACKAGE"
+ln -f "$PACKAGE" "$OUTPUT_DIR/applaunch_arm64.deb"
+(
+    cd "$OUTPUT_DIR"
+    sha256sum applaunch_arm64.deb > applaunch_arm64.deb.sha256
+    sha256sum -c applaunch_arm64.deb.sha256
+)
+printf '1\n' >"$OUTPUT_DIR/applaunch_arm64.deb.update-abi"
+printf '%s\n' "$PACKAGE" >"$OUTPUT_DIR/applaunch-package.path"
+echo "Stable package: $OUTPUT_DIR/applaunch_arm64.deb"
+echo "Checksum: $OUTPUT_DIR/applaunch_arm64.deb.sha256"
+echo "Update ABI: $OUTPUT_DIR/applaunch_arm64.deb.update-abi"
+echo "Result path: $OUTPUT_DIR/applaunch-package.path"

--- a/scripts/cardputer_adb_hotplug.c
+++ b/scripts/cardputer_adb_hotplug.c
@@ -1,0 +1,245 @@
+#define _GNU_SOURCE
+
+#include <ctype.h>
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+static volatile sig_atomic_t stop_requested;
+
+static void request_stop(int signal_number)
+{
+    (void)signal_number;
+    stop_requested = 1;
+}
+
+static bool numeric_name(const char *name)
+{
+    if (!name || !*name) return false;
+    for (const unsigned char *p = (const unsigned char *)name; *p; ++p) {
+        if (!isdigit(*p)) return false;
+    }
+    return true;
+}
+
+static bool read_first_line(const char *path, char *buffer, size_t size)
+{
+    if (!path || !buffer || size < 2) return false;
+    int fd = open(path, O_RDONLY | O_CLOEXEC);
+    if (fd < 0) return false;
+    const ssize_t count = read(fd, buffer, size - 1);
+    close(fd);
+    if (count <= 0) return false;
+    buffer[count] = '\0';
+    buffer[strcspn(buffer, "\r\n")] = '\0';
+    return true;
+}
+
+static pid_t find_adbd(void)
+{
+    DIR *proc = opendir("/proc");
+    if (!proc) return 0;
+    pid_t result = 0;
+    struct dirent *entry;
+    while ((entry = readdir(proc)) != NULL) {
+        if (!numeric_name(entry->d_name)) continue;
+        char path[PATH_MAX];
+        char name[32];
+        if (snprintf(path, sizeof(path), "/proc/%s/comm", entry->d_name) >=
+            (int)sizeof(path))
+            continue;
+        if (read_first_line(path, name, sizeof(name)) && strcmp(name, "adbd") == 0) {
+            result = (pid_t)strtol(entry->d_name, NULL, 10);
+            break;
+        }
+    }
+    closedir(proc);
+    return result;
+}
+
+static bool adbd_has_functionfs(void)
+{
+    const pid_t pid = find_adbd();
+    if (pid <= 0) return false;
+
+    char directory[64];
+    if (snprintf(directory, sizeof(directory), "/proc/%ld/fd", (long)pid) >=
+        (int)sizeof(directory))
+        return false;
+    DIR *fds = opendir(directory);
+    if (!fds) return false;
+
+    bool found = false;
+    struct dirent *entry;
+    while ((entry = readdir(fds)) != NULL) {
+        if (entry->d_name[0] == '.') continue;
+        char path[PATH_MAX];
+        char target[PATH_MAX];
+        if (snprintf(path, sizeof(path), "%s/%s", directory, entry->d_name) >=
+            (int)sizeof(path))
+            continue;
+        const ssize_t count = readlink(path, target, sizeof(target) - 1);
+        if (count <= 0) continue;
+        target[count] = '\0';
+        if (strcmp(target, "/dev/usb-ffs/adb/ep0") == 0) {
+            found = true;
+            break;
+        }
+    }
+    closedir(fds);
+    return found;
+}
+
+static int find_udc_state(const char *root, char *path, size_t size)
+{
+    char directory[PATH_MAX];
+    if (snprintf(directory, sizeof(directory), "%s/sys/class/udc", root) >=
+        (int)sizeof(directory))
+        return -1;
+    DIR *udcs = opendir(directory);
+    if (!udcs) return -1;
+
+    int fd = -1;
+    struct dirent *entry;
+    while ((entry = readdir(udcs)) != NULL) {
+        if (entry->d_name[0] == '.') continue;
+        if (snprintf(path, size, "%s/%s/state", directory, entry->d_name) >= (int)size)
+            continue;
+        fd = open(path, O_RDONLY | O_CLOEXEC);
+        if (fd >= 0) break;
+    }
+    closedir(udcs);
+    return fd;
+}
+
+static bool read_udc_state(int fd, char *state, size_t size)
+{
+    if (!state || size < 2) return false;
+    if (lseek(fd, 0, SEEK_SET) < 0) return false;
+    const ssize_t count = read(fd, state, size - 1);
+    if (count <= 0) return false;
+    state[count] = '\0';
+    state[strcspn(state, "\r\n")] = '\0';
+    return true;
+}
+
+static bool state_needs_transport(const char *state)
+{
+    return state && (strcmp(state, "configured") == 0 || strcmp(state, "suspended") == 0);
+}
+
+static int restart_adbd(void)
+{
+    pid_t child = fork();
+    if (child < 0) return -1;
+    if (child == 0) {
+        execlp("systemctl", "systemctl", "restart", "adbd.service", (char *)NULL);
+        _exit(127);
+    }
+    int status = 0;
+    while (waitpid(child, &status, 0) < 0) {
+        if (errno != EINTR) return -1;
+    }
+    return WIFEXITED(status) && WEXITSTATUS(status) == 0 ? 0 : -1;
+}
+
+static void sleep_milliseconds(long milliseconds)
+{
+    struct timespec delay = {
+        .tv_sec = milliseconds / 1000,
+        .tv_nsec = (milliseconds % 1000) * 1000000L,
+    };
+    while (!stop_requested && nanosleep(&delay, &delay) < 0 && errno == EINTR) {
+    }
+}
+
+int main(void)
+{
+    const char *root = "";
+    int timeout_ms = 5000;
+    if (geteuid() != 0) {
+        const char *test_root = getenv("CARDPUTER_ADB_TEST_ROOT");
+        const char *test_timeout = getenv("CARDPUTER_ADB_HOTPLUG_TIMEOUT_MS");
+        if (test_root && *test_root) root = test_root;
+        if (test_timeout && atoi(test_timeout) >= 10) timeout_ms = atoi(test_timeout);
+    }
+
+    struct sigaction action;
+    memset(&action, 0, sizeof(action));
+    action.sa_handler = request_stop;
+    sigemptyset(&action.sa_mask);
+    sigaction(SIGTERM, &action, NULL);
+    sigaction(SIGINT, &action, NULL);
+
+    int state_fd = -1;
+    char state_path[PATH_MAX];
+    time_t last_restart = 0;
+    const time_t started = time(NULL);
+    while (!stop_requested) {
+        if (state_fd < 0) {
+            state_fd = find_udc_state(root, state_path, sizeof(state_path));
+            if (state_fd < 0) {
+                sleep_milliseconds(1000);
+                continue;
+            }
+            char initial_state[64];
+            (void)read_udc_state(state_fd, initial_state, sizeof(initial_state));
+        }
+
+        struct pollfd descriptor = {
+            .fd = state_fd,
+            .events = POLLPRI | POLLERR,
+            .revents = 0,
+        };
+        const int ready = poll(&descriptor, 1, timeout_ms);
+        if (ready < 0 && errno != EINTR) {
+            close(state_fd);
+            state_fd = -1;
+            continue;
+        }
+        if (stop_requested) break;
+
+        char state[64];
+        if (!read_udc_state(state_fd, state, sizeof(state))) {
+            close(state_fd);
+            state_fd = -1;
+            continue;
+        }
+        if (!state_needs_transport(state)) continue;
+        const bool state_changed = ready > 0 &&
+            (descriptor.revents & (POLLPRI | POLLERR)) != 0;
+        const bool transport_missing = !adbd_has_functionfs();
+        if (!state_changed && !transport_missing) continue;
+
+        const time_t now = time(NULL);
+        if (state_changed && !transport_missing && started != (time_t)-1 &&
+            now != (time_t)-1 && now - started <= 5)
+            continue;
+        if (now != (time_t)-1 && last_restart != 0 && now - last_restart <= 5) continue;
+        last_restart = now;
+        fprintf(stderr,
+                "USB entered %s state%s; restarting adbd\n",
+                state,
+                transport_missing ? " without a FunctionFS transport" : "");
+        if (restart_adbd() != 0) {
+            fprintf(stderr, "failed to restart adbd.service\n");
+        }
+        close(state_fd);
+        state_fd = -1;
+        sleep_milliseconds(2000);
+    }
+
+    if (state_fd >= 0) close(state_fd);
+    return 0;
+}

--- a/scripts/debian_packager.py
+++ b/scripts/debian_packager.py
@@ -16,7 +16,7 @@ import subprocess
 import sys
 import tarfile
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Iterable, Sequence
 
@@ -34,6 +34,7 @@ SERVICE_PATH = PurePosixPath("usr/lib/systemd/user")
 SYSTEM_SERVICE_PATH = PurePosixPath("usr/lib/systemd/system")
 POLKIT_RULES_PATH = PurePosixPath("usr/share/polkit-1/rules.d")
 LIBEXEC_PATH = PurePosixPath("usr/libexec")
+LAUNCHER_UPDATE_ABI = "1"
 
 OPTIONAL_BINARIES = (
     "M5CardputerZero-AppStore",
@@ -169,7 +170,21 @@ def _copy_optional_binaries(src_dir: Path, package_root: Path, config: PackageCo
     return copied
 
 
+def _source_date_epoch() -> int:
+    value = os.environ.get("SOURCE_DATE_EPOCH")
+    if value is None:
+        return int(datetime.now(timezone.utc).timestamp())
+    try:
+        epoch = int(value)
+    except ValueError as exc:
+        raise PackError("SOURCE_DATE_EPOCH must be an integer") from exc
+    if epoch < 0:
+        raise PackError("SOURCE_DATE_EPOCH must not be negative")
+    return epoch
+
+
 def _control_text(config: PackageConfig) -> str:
+    packaged_at = datetime.fromtimestamp(_source_date_epoch(), timezone.utc)
     fields = {
         "Package": config.package_name,
         "Version": config.version,
@@ -179,9 +194,11 @@ def _control_text(config: PackageConfig) -> str:
         "Section": config.section,
         "Priority": config.priority,
         "Homepage": config.homepage,
-        "Packaged-Date": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        "Packaged-Date": packaged_at.strftime("%Y-%m-%d %H:%M:%S UTC"),
         "Description": config.description,
     }
+    if config.app_name == APP_NAME and config.package_name == PACKAGE_NAME:
+        fields["X-CardputerZero-Update-ABI"] = LAUNCHER_UPDATE_ABI
     return "".join(f"{key}: {value}\n" for key, value in fields.items())
 
 
@@ -353,7 +370,7 @@ Wants=network-online.target
 [Service]
 Type=oneshot
 ExecStart=/usr/libexec/applaunch-updater
-TimeoutStartSec=10min
+TimeoutStartSec=20min
 Nice=10
 IOSchedulingClass=best-effort
 IOSchedulingPriority=7
@@ -375,7 +392,9 @@ Nice=10
 
 
 def _updater_polkit_text() -> str:
-    return """// Permit a local interactive session to start only the fixed updater unit.
+    return """// Permit a local administrator to start only the fixed updater units.
+// APPLaunch runs as a systemd user service, so it is not attached to the
+// active seat even though it owns the physical device UI.
 polkit.addRule(function(action, subject) {
     if (action.id == "org.freedesktop.systemd1.manage-units" &&
         (action.lookup("unit") == "applaunch-updater.service" ||
@@ -383,7 +402,7 @@ polkit.addRule(function(action, subject) {
         (action.lookup("verb") == "start" ||
          (action.lookup("verb") == "stop" &&
           action.lookup("unit") == "applaunch-apt-update.service")) &&
-        subject.local && subject.active) {
+        subject.isInGroup("sudo")) {
         return polkit.Result.YES;
     }
 });
@@ -398,7 +417,9 @@ set -eu
 # private runtime copy so replacing /usr/libexec/applaunch-updater cannot alter
 # the script that is currently coordinating install and rollback.
 if [ "${APPLAUNCH_UPDATER_REEXEC:-0}" != 1 ]; then
-    self_dir=$(mktemp -d /run/applaunch-updater.XXXXXX)
+    state_root=${APPLAUNCH_UPDATE_STATE_DIR:-/var/lib/applaunch-updater}
+    install -d -m 0755 "$state_root"
+    self_dir=$(mktemp -d "$state_root/self.XXXXXX")
     install -m 0700 "$0" "$self_dir/updater"
     exec env APPLAUNCH_UPDATER_REEXEC=1 APPLAUNCH_UPDATER_SELF_DIR="$self_dir" \
         "$self_dir/updater"
@@ -407,13 +428,14 @@ SELF_DIR=${APPLAUNCH_UPDATER_SELF_DIR:-}
 
 PACKAGE_NAME=${APPLAUNCH_UPDATE_PACKAGE_NAME:-applaunch}
 ARCHITECTURE=${APPLAUNCH_UPDATE_ARCHITECTURE:-arm64}
+UPDATE_ABI=${APPLAUNCH_UPDATE_ABI:-1}
 RELEASE_ROOT=${APPLAUNCH_UPDATE_RELEASE_ROOT:-https://github.com/CardputerZero/launcher/releases/download}
 RELEASE_URL=${APPLAUNCH_UPDATE_RELEASE_URL:-$RELEASE_ROOT/launcher-latest}
 STATE_DIR=${APPLAUNCH_UPDATE_STATE_DIR:-/var/lib/applaunch-updater}
 CACHE_DIR=${APPLAUNCH_UPDATE_CACHE_DIR:-/var/cache/APPLaunch/updates}
 STATUS_FILE=$STATE_DIR/status
 APP_UID=${APPLAUNCH_UPDATE_UID:-1000}
-APP_EXECUTABLE=${APPLAUNCH_UPDATE_EXECUTABLE:-/usr/bin/M5CardputerZero-APPLaunch}
+APP_EXECUTABLE=${APPLAUNCH_UPDATE_EXECUTABLE:-/usr/share/APPLaunch/bin/M5CardputerZero-APPLaunch}
 PROC_ROOT=${APPLAUNCH_UPDATE_PROC_ROOT:-/proc}
 
 mkdir -p "$STATE_DIR" "$CACHE_DIR"
@@ -425,6 +447,7 @@ flock -n 9 || exit 0
 tmp_dir=$(mktemp -d "$STATE_DIR/run.XXXXXX")
 package=$tmp_dir/applaunch_arm64.deb
 checksum=$tmp_dir/applaunch_arm64.deb.sha256
+abi_file=$tmp_dir/applaunch_arm64.deb.update-abi
 phase=starting
 cleanup() { rm -rf "$tmp_dir"; [ -z "$SELF_DIR" ] || rm -rf "$SELF_DIR"; }
 trap cleanup EXIT
@@ -495,6 +518,8 @@ rollback_and_fail() {
 previous_status=$(sed -n '1p' "$STATUS_FILE" 2>/dev/null || true)
 phase=downloading
 status downloading
+wget -q --https-only --timeout=30 --tries=3 "$RELEASE_URL/applaunch_arm64.deb.update-abi" -O "$abi_file" || fail incompatible
+[ "$(tr -d '[:space:]' <"$abi_file")" = "$UPDATE_ABI" ] || fail incompatible
 wget -q --https-only --timeout=30 --tries=3 "$RELEASE_URL/applaunch_arm64.deb" -O "$package" || fail download-package
 wget -q --https-only --timeout=30 --tries=3 "$RELEASE_URL/applaunch_arm64.deb.sha256" -O "$checksum" || fail download-checksum
 expected=$(awk 'NF && $1 ~ /^[0-9a-fA-F]{64}$/ { print tolower($1); exit }' "$checksum")
@@ -504,6 +529,7 @@ actual=$(sha256sum "$package" | awk '{print $1}')
 
 [ "$(dpkg-deb -f "$package" Package)" = "$PACKAGE_NAME" ] || fail package-name
 [ "$(dpkg-deb -f "$package" Architecture)" = "$ARCHITECTURE" ] || fail architecture
+[ "$(dpkg-deb -f "$package" X-CardputerZero-Update-ABI 2>/dev/null || true)" = "$UPDATE_ABI" ] || fail incompatible
 candidate=$(dpkg-deb -f "$package" Version)
 installed=$(dpkg-query -W -f='${Version}' "$PACKAGE_NAME" 2>/dev/null) || fail installed-version
 audit=$(dpkg --audit 2>/dev/null || true)
@@ -719,6 +745,7 @@ def _tar_filter(tar_info: tarfile.TarInfo) -> tarfile.TarInfo:
     tar_info.gid = 0
     tar_info.uname = "root"
     tar_info.gname = "root"
+    tar_info.mtime = _source_date_epoch()
     if tar_info.isdir():
         tar_info.mode = 0o755
     elif tar_info.mode & 0o111:
@@ -750,7 +777,7 @@ def _ar_member_header(name: str, size: int, mode: int = 0o100644) -> bytes:
         raise PackError(f"ar member name too long: {name}")
     header = (
         f"{name + '/':<16}"
-        f"{int(datetime.now().timestamp()):<12}"
+        f"{_source_date_epoch():<12}"
         f"{0:<6}"
         f"{0:<6}"
         f"{format(mode, 'o'):<8}"


### PR DESCRIPTION
## Summary

- preserve ExtPort and ADB settings across power cycles and recover ADB after USB reconnects
- remove manual date/time setup while preserving the remaining OOBE flow
- restore CLI paging shortcuts and unmute before volume-key adjustments
- use packaged JetBrains Mono for ZClaw's ambiguous Latin/digit glyphs
- keep Settings prompt sounds while preventing rapid page entry/exit from repeatedly tearing down the audio stream
- make Update actions authorized, bounded, rollback-capable, and package local/cloud Launcher payloads through one script

## Factory sync and conflicts

This branch is based on current `CardputerZero/launcher@c92874968507` (`ahead=0`, `behind=0` before these commits). The earlier local audio lifecycle branch was already absorbed by upstream PR #138 and was not replayed. No unresolved merge conflict remains.

The only factory-sync text conflict in the wider image stack was in `pi-gen/stage2/05-cardputerzero/01-run.sh`; that is handled in the separate pi-gen PR by retaining the upstream script and adding an isolated ExtPort permissions patch. This Launcher PR does not revert LightDM, DAPM, camera, font-package, or other factory changes.

## Dependency

Depends on m5stack/M5Stack_Linux_Libs#11. That PR passes `SOURCE_DATE_EPOCH` into GCC from the SDK SCons environment. After it merges into `UserDemo`, this branch still needs one follow-up commit updating the `SDK` gitlink to the merged upstream commit. Do not merge this PR before that gitlink update: without it, runtime functionality builds, but local/cloud package reproducibility is not guaranteed.

## Validation

- focused ExtPort, OOBE, ADB, CLI, media, updater, and audio quiet-period tests passed
- local/prerelease/local full clean package build completed; both local `.deb` files were byte-identical
- package contains all five ARM64 product ELF files and `cardputer-adb-hotplug`; update ABI is 1 and SHA-256 verifies
- board package upgrade preserved every file hash under `/home/pi/.config`; APPLaunch remained active with one PID and `NRestarts=0`
- user confirmed normal prompt sounds remain and the previously reproducible Settings buzz is gone; rapid navigation may still expose the existing factory `Loading...` page template

Full image construction and offline verification run separately in pi-gen. Fresh-media OOBE, cold-start performance, display, audio listening, and hardware regression still require device validation before release.
