### PR TITLE
fix(applaunch): keep carousel icon borders consistent

### DIFF
--- a/projects/APPLaunch/main/ui/ui_launch_page_carousel_view.cpp
+++ b/projects/APPLaunch/main/ui/ui_launch_page_carousel_view.cpp
@@ -59,6 +59,7 @@ lv_obj_t *create_carousel_card(lv_obj_t *parent, const Slot &slot,
     lv_obj_set_style_bg_opa(card, LV_OPA_TRANSP, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_border_color(card, lv_color_hex(border_color), LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_border_opa(card, LV_OPA_COVER, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_border_post(card, true, LV_PART_MAIN | LV_STATE_DEFAULT);
     return card;
 }
 
@@ -224,8 +225,6 @@ void UILaunchPage::create_app_container(lv_obj_t *parent)
         lv_obj_delete(container);
         return;
     }
-    lv_obj_set_style_border_width(elements[kCardCenter], 2, LV_PART_MAIN | LV_STATE_DEFAULT);
-
     *carousel_alive_ = false;
     if (carousel_container_) lv_obj_delete(carousel_container_);
     carousel_alive_ = std::make_shared<bool>(true);

--- a/projects/APPLaunch/tests/run_tests.sh
+++ b/projects/APPLaunch/tests/run_tests.sh
@@ -2,6 +2,7 @@
 set -eu
 python3 "$(dirname "$0")/test_store_cache_sync.py"
 python3 "$(dirname "$0")/test_wifi_view_lifecycle_contract.py"
+python3 "$(dirname "$0")/test_carousel_border_contract.py"
 python3 "$(dirname "$0")/test_bluetooth_power_contract.py"
 python3 "$(dirname "$0")/test_external_framebuffer_ownership.py"
 PYTHONPATH="$(dirname "$0")/..${PYTHONPATH:+:$PYTHONPATH}" \

--- a/projects/APPLaunch/tests/test_carousel_border_contract.py
+++ b/projects/APPLaunch/tests/test_carousel_border_contract.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+SOURCE = (
+    Path(__file__).resolve().parents[1]
+    / "main/ui/ui_launch_page_carousel_view.cpp"
+).read_text(encoding="utf-8")
+
+
+def test_every_carousel_card_keeps_the_theme_border():
+    start = SOURCE.index("lv_obj_t *create_carousel_card")
+    end = SOURCE.index("lv_obj_t *create_carousel_title", start)
+    factory = SOURCE[start:end]
+    assert "lv_obj_set_style_border_width(card," not in factory
+    assert "lv_obj_set_style_border_width(elements[kCardCenter]" not in SOURCE
+    assert "lv_obj_set_style_border_post(card, true," in factory
+
+
+if __name__ == "__main__":
+    test_every_carousel_card_keeps_the_theme_border()


### PR DESCRIPTION
## Summary

- keep all five reusable carousel cards on the LVGL theme's DPI-scaled border width
- render each card border after its icon so opaque edge pixels cannot cover the frame
- add a focused source contract test to prevent fixed-width or pre-child border regressions

## Root cause

The carousel reuses five card objects while rotating application content through them. Only the initially centered card overrode the theme border with a literal 2 px width, so applications appeared to inherit a thin border depending on which reusable card they occupied. FactoryTest's nearly full-canvas opaque icon also covered part of the parent card border because the border was drawn before child content.

## Validation

- `python3 projects/APPLaunch/tests/test_carousel_border_contract.py`
- `projects/APPLaunch/tests/run_tests.sh`
- `git diff --check`
- clean ARM64 aggregate package build covering APPLaunch, AppStore, Calculator, LaunchWizard and ZClaw
- installed on CardputerZero and captured 30 framebuffer frames while rotating every menu entry; SSH, Snake, IR Remote, NFC and FactoryTest all retain the same theme-width frame, with `APPLaunch.service` active and `NRestarts=0`

## Scope and side effects

No PNG files, independent application repositories, card dimensions, colors, focus behavior, application order, services or threads change. `border_post` makes the existing frame cover the outermost pixels of full-canvas icons; this is intentional so every application keeps a visible frame.
