### PR TITLE
chore: point AppStore submodule at CardputerZero/Store latest

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,7 +10,7 @@
 	url = https://github.com/CardputerZero/Calculator.git
 [submodule "projects/AppStore"]
 	path = projects/AppStore
-	url = https://github.com/CardputerZero/AppStore.git
+	url = git@github.com:CardputerZero/Store.git
 	branch = main
 [submodule "projects/CameraApp/main_CameraApp"]
 	path = projects/CameraApp/main_CameraApp


### PR DESCRIPTION
The AppStore repository moved to CardputerZero/Store.git. Track the renamed remote and pin to 65f1225 so launcher builds pick up native HTTPS registry sync and package-repair hardening.