### PR TITLE
fix: use HTTPS for AppStore/Store submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,7 +10,7 @@
 	url = https://github.com/CardputerZero/Calculator.git
 [submodule "projects/AppStore"]
 	path = projects/AppStore
-	url = git@github.com:CardputerZero/Store.git
+	url = https://github.com/CardputerZero/Store.git
 	branch = main
 [submodule "projects/CameraApp/main_CameraApp"]
 	path = projects/CameraApp/main_CameraApp


### PR DESCRIPTION
## Why

PR #144 changed `projects/AppStore` to `CardputerZero/Store.git`, but the submodule URL was SSH:

`git@github.com:CardputerZero/Store.git`

CI `build` failed in **Initialize submodules (SDK + AppStore + Calculator)** because the runner has no deploy key:

```
git@github.com: Permission denied (publickey).
fatal: clone of 'git@github.com:CardputerZero/Store.git' into submodule path '.../projects/AppStore' failed
```

This also broke the `master` push build after merge:
https://github.com/CardputerZero/launcher/actions/runs/31962498562

## Change

Use `https://github.com/CardputerZero/Store.git`, matching Calculator/CameraApp/FactoryTest.

Store remains public and still pins `65f1225`.