### PR TITLE
首启键盘引导 + Imager 配置后自动跳过 OOBE + 默认目录修复

### DIFF
--- a/projects/LaunchWizard/CMakeLists.txt
+++ b/projects/LaunchWizard/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(launch_wizard_core
     main/ui/account_migration.cpp
     main/ui/apply_checkpoint.cpp
     main/ui/command_runner.cpp
+    main/ui/first_boot_policy.cpp
     main/ui/manual_datetime_validation.cpp
     main/ui/service_handoff.cpp
     main/ui/wizard_model.cpp
@@ -45,6 +46,7 @@ if(BUILD_TESTING)
         tests/test_apply_checkpoint.cpp
         tests/test_manual_datetime_validation.cpp
         tests/test_command_runner.cpp
+        tests/test_first_boot_policy.cpp
         tests/test_service_handoff.cpp
         tests/test_wizard_model.cpp
     )

--- a/projects/LaunchWizard/main/src/main.cpp
+++ b/projects/LaunchWizard/main/src/main.cpp
@@ -33,6 +33,11 @@ int main(int argc, char *argv[])
     if (force)
         printf("LaunchWizard: test mode, bypassing first-boot detection\n");
 
+    // The keyboard tutorial runs first and exactly once per device, whether
+    // the OOBE that follows is shown or skipped (Imager-provisioned devices).
+    if (!force)
+        launch_wizard_run_keyboard_guide_once();
+
     if (!force && !launch_wizard_should_run()) {
         printf("LaunchWizard: first-boot desktop is not active, starting APPLaunch\n");
         const int handoff_result = launch_wizard_finish_configured_system();

--- a/projects/LaunchWizard/main/ui/application.h
+++ b/projects/LaunchWizard/main/ui/application.h
@@ -13,4 +13,8 @@ void launch_wizard_ui_teardown(void);
 bool launch_wizard_should_run(void);
 int launch_wizard_finish_configured_system(void);
 
+// Shows the one-shot keyboard tutorial before the OOBE decision. Runs exactly
+// once per device (marker baked by pi-gen), whether or not the wizard follows.
+void launch_wizard_run_keyboard_guide_once(void);
+
 #endif  // LAUNCH_WIZARD_APPLICATION_H

--- a/projects/LaunchWizard/main/ui/first_boot_policy.cpp
+++ b/projects/LaunchWizard/main/ui/first_boot_policy.cpp
@@ -1,0 +1,19 @@
+#include "first_boot_policy.h"
+
+namespace launch_wizard {
+
+bool should_run_wizard(const FirstBootState &state)
+{
+    if (state.rearm_marker)
+        return true;
+    if (state.factory_marker)
+        return !state.user_has_password;
+    return state.legacy_piwiz_active;
+}
+
+bool should_run_keyboard_guide(bool marker_present, bool binary_present)
+{
+    return marker_present && binary_present;
+}
+
+}  // namespace launch_wizard

--- a/projects/LaunchWizard/main/ui/first_boot_policy.h
+++ b/projects/LaunchWizard/main/ui/first_boot_policy.h
@@ -1,0 +1,34 @@
+#ifndef LAUNCH_WIZARD_FIRST_BOOT_POLICY_H
+#define LAUNCH_WIZARD_FIRST_BOOT_POLICY_H
+
+namespace launch_wizard {
+
+// Snapshot of the on-disk first-boot signals, gathered by the caller so the
+// decision itself stays a pure, unit-testable function.
+struct FirstBootState {
+    // /var/lib/applaunch/run-oobe: dropped by APPLaunch's "Run Setup Wizard"
+    // settings entry to replay the OOBE on demand.
+    bool rearm_marker = false;
+    // /var/lib/LaunchWizard/run-oobe: baked into every factory image by pi-gen.
+    bool factory_marker = false;
+    // The UID 1000 user's shadow entry holds a real "$..." hash, meaning the
+    // account was configured (Raspberry Pi Imager, a finished OOBE, ...).
+    bool user_has_password = false;
+    // Legacy piwiz/lightdm first-boot autologin is still armed.
+    bool legacy_piwiz_active = false;
+};
+
+// A user-requested re-run always shows the wizard. The factory marker only
+// shows it while no account has been configured yet: a device provisioned
+// through Raspberry Pi Imager already has a password, so first boot must skip
+// straight to the launcher.
+bool should_run_wizard(const FirstBootState &state);
+
+// The keyboard guide runs exactly once per device, before and independently of
+// the OOBE wizard. A missing binary keeps the marker so a later boot (e.g.
+// after the package lands) can still show the guide.
+bool should_run_keyboard_guide(bool marker_present, bool binary_present);
+
+}  // namespace launch_wizard
+
+#endif  // LAUNCH_WIZARD_FIRST_BOOT_POLICY_H

--- a/projects/LaunchWizard/main/ui/wizard_service.cpp
+++ b/projects/LaunchWizard/main/ui/wizard_service.cpp
@@ -2,6 +2,7 @@
 #include "account_migration.h"
 #include "apply_checkpoint.h"
 #include "command_runner.h"
+#include "first_boot_policy.h"
 #include "service_handoff.h"
 
 #include "global_config.h"
@@ -15,11 +16,16 @@
 #include <fcntl.h>
 #include <pwd.h>
 #include <shadow.h>
+#include <signal.h>
+#include <spawn.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
+
+extern char **environ;
 
 #include <chrono>
 #include <fstream>
@@ -48,6 +54,27 @@ constexpr const char *kAccountJournalDir = "/var/lib/LaunchWizard";
 constexpr const char *kAccountJournalPath =
     "/var/lib/LaunchWizard/account-migration.state";
 #endif
+
+// Dropped by APPLaunch's "Run Setup Wizard" settings entry (re-run on demand).
+constexpr const char *kRearmOobeMarker = "/var/lib/applaunch/run-oobe";
+// Baked into every factory image by pi-gen; removed once first boot finishes.
+constexpr const char *kFactoryOobeMarker = "/var/lib/LaunchWizard/run-oobe";
+// One-shot keyboard tutorial shown before the OOBE (also baked by pi-gen).
+constexpr const char *kKeyboardGuideMarker =
+    "/var/lib/LaunchWizard/run-keyboard-guide";
+constexpr const char *kKeyboardGuideBinary =
+    "/usr/share/APPLaunch/bin/M5CardputerZero-Keyboard-Guide";
+
+void remove_oobe_markers(std::string *first_error = nullptr)
+{
+    static const char *marker_paths[] = {kRearmOobeMarker, kFactoryOobeMarker};
+    for (const char *path : marker_paths) {
+        if (remove(path) != 0 && errno != ENOENT && first_error &&
+            first_error->empty())
+            *first_error = std::string("Failed to remove OOBE marker: ") +
+                           strerror(errno);
+    }
+}
 
 void print_command(const std::vector<std::string> &args, const std::string *stdin_text)
 {
@@ -932,15 +959,7 @@ std::string WizardService::apply(
                 first_error = disabled.output.empty()
                     ? std::string("Failed to disable LaunchWizard.service")
                     : disabled.output;
-            static const char *marker_paths[] = {
-                "/var/lib/applaunch/run-oobe",
-                "/var/lib/LaunchWizard/run-oobe",
-            };
-            for (const char *path : marker_paths) {
-                if (remove(path) != 0 && errno != ENOENT && first_error.empty())
-                    first_error = std::string("Failed to remove OOBE marker: ") +
-                                  strerror(errno);
-            }
+            remove_oobe_markers(&first_error);
 #if !LAUNCH_WIZARD_DRY_RUN
             sync();
             sync();
@@ -977,20 +996,85 @@ bool launch_wizard::WizardService::should_run()
     // In the SDL emulator always show the OOBE so it can be developed/previewed.
     return true;
 #else
-    // Explicit re-arm marker. APPLaunch's "Run Setup Wizard" settings entry
-    // drops this file and reboots, letting an already-configured device replay
-    // the OOBE on demand. apply_all() clears it on completion, so the wizard
-    // still runs exactly once.
-    static const char *kRearmPaths[] = {
-        "/var/lib/applaunch/run-oobe",
-        "/var/lib/LaunchWizard/run-oobe",
-    };
-    for (const char *path : kRearmPaths) {
-        if (access(path, F_OK) == 0)
-            return true;
+    FirstBootState state;
+    // APPLaunch's "Run Setup Wizard" settings entry drops this file and
+    // reboots, letting an already-configured device replay the OOBE on demand.
+    // apply_all() clears it on completion, so the wizard still runs exactly
+    // once.
+    state.rearm_marker = access(kRearmOobeMarker, F_OK) == 0;
+    // pi-gen bakes the factory marker into every image. It must only trigger
+    // the OOBE while the account is still unconfigured; a device provisioned
+    // through Raspberry Pi Imager already has a password and skips straight to
+    // the launcher (finish_configured_system() then removes the marker).
+    state.factory_marker = access(kFactoryOobeMarker, F_OK) == 0;
+    state.user_has_password = first_user_has_password();
+    state.legacy_piwiz_active =
+        lightdm_autologin_user() == kFirstBootWizardUser && piwiz_autostart_enabled();
+    return should_run_wizard(state);
+#endif
+}
+
+void launch_wizard::WizardService::run_keyboard_guide_once()
+{
+#if LAUNCH_WIZARD_DRY_RUN
+    // The guide is a separate on-device binary; nothing to preview in SDL.
+    return;
+#else
+    const bool marker_present = access(kKeyboardGuideMarker, F_OK) == 0;
+    const bool binary_present = access(kKeyboardGuideBinary, X_OK) == 0;
+    if (!should_run_keyboard_guide(marker_present, binary_present)) {
+        if (marker_present)
+            fprintf(stderr,
+                    "LaunchWizard: keyboard guide binary missing; skipping guide\n");
+        return;
     }
 
-    return lightdm_autologin_user() == kFirstBootWizardUser && piwiz_autostart_enabled();
+    // Consume the marker *before* exec: if the guide ever hangs and the user
+    // power-cycles, the next boot must not be trapped in the guide again.
+    if (remove(kKeyboardGuideMarker) != 0 && errno != ENOENT) {
+        fprintf(stderr, "LaunchWizard: failed to remove keyboard guide marker: %s\n",
+                strerror(errno));
+        return;  // Without the consumed marker, re-running is worse than skipping.
+    }
+    sync();
+
+    printf("LaunchWizard: starting keyboard guide\n");
+    fflush(stdout);
+
+    // The guide is interactive and can stay open for minutes. Intentionally
+    // not run_command(): that captures stdout/stderr into a bounded buffer
+    // (hiding the guide's logs from journald), busy-polls at 20ms, and is
+    // built around a timeout. posix_spawn + blocking waitpid inherits our
+    // stdio, costs nothing while waiting, and reports exec errors directly.
+    char *argv[] = {const_cast<char *>(kKeyboardGuideBinary), nullptr};
+    posix_spawnattr_t attr;
+    posix_spawnattr_init(&attr);
+    // Give the guide default signal dispositions regardless of what the
+    // wizard's runtime may have changed (e.g. an ignored SIGPIPE).
+    sigset_t default_signals;
+    sigfillset(&default_signals);
+    posix_spawnattr_setsigdefault(&attr, &default_signals);
+    posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETSIGDEF);
+
+    pid_t pid = -1;
+    const int spawn_error =
+        posix_spawn(&pid, kKeyboardGuideBinary, nullptr, &attr, argv, environ);
+    posix_spawnattr_destroy(&attr);
+    if (spawn_error != 0) {
+        fprintf(stderr, "LaunchWizard: failed to start keyboard guide: %s\n",
+                strerror(spawn_error));
+        return;
+    }
+
+    int status = 0;
+    while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {
+    }
+    if (WIFSIGNALED(status))
+        fprintf(stderr, "LaunchWizard: keyboard guide killed by signal %d\n",
+                WTERMSIG(status));
+    else if (WIFEXITED(status) && WEXITSTATUS(status) != 0)
+        fprintf(stderr, "LaunchWizard: keyboard guide exited with %d\n",
+                WEXITSTATUS(status));
 #endif
 }
 
@@ -1018,6 +1102,13 @@ int launch_wizard::WizardService::finish_configured_system()
         fprintf(stderr, "LaunchWizard: %s\n", service_warning.c_str());
         return 1;
     }
+
+    // The device counts as configured (Imager provisioning or a finished
+    // OOBE), so drop any leftover factory marker to keep future boots clean.
+    remove_oobe_markers();
+#if !LAUNCH_WIZARD_DRY_RUN
+    sync();
+#endif
 
     printf("LaunchWizard: started APPLaunch for %s and disabled LaunchWizard.service\n",
            user.c_str());

--- a/projects/LaunchWizard/main/ui/wizard_service.h
+++ b/projects/LaunchWizard/main/ui/wizard_service.h
@@ -36,6 +36,9 @@ public:
     static std::string reboot();
     static bool should_run();
     static int finish_configured_system();
+    // Runs the one-shot keyboard tutorial (before the OOBE decision) and
+    // consumes its marker. Returns once the guide exits or is unavailable.
+    static void run_keyboard_guide_once();
 };
 
 }  // namespace launch_wizard

--- a/projects/LaunchWizard/main/ui/wizard_view.cpp
+++ b/projects/LaunchWizard/main/ui/wizard_view.cpp
@@ -1475,6 +1475,11 @@ int launch_wizard_finish_configured_system(void)
     return launch_wizard::WizardService::finish_configured_system();
 }
 
+void launch_wizard_run_keyboard_guide_once(void)
+{
+    launch_wizard::WizardService::run_keyboard_guide_once();
+}
+
 void launch_wizard_register_event(void)
 {
     if (LV_EVENT_KEYBOARD == 0) LV_EVENT_KEYBOARD = lv_event_register_id();

--- a/projects/LaunchWizard/tests/test_first_boot_policy.cpp
+++ b/projects/LaunchWizard/tests/test_first_boot_policy.cpp
@@ -1,0 +1,57 @@
+#include "first_boot_policy.h"
+
+#include <iostream>
+#include <string>
+
+namespace {
+
+bool expect_wizard(bool expected, const launch_wizard::FirstBootState &state,
+                   const std::string &label)
+{
+    const bool actual = launch_wizard::should_run_wizard(state);
+    if (actual == expected)
+        return true;
+    std::cerr << "should_run_wizard mismatch (" << label << "): expected "
+              << expected << ", got " << actual << "\n";
+    return false;
+}
+
+}  // namespace
+
+bool test_first_boot_policy()
+{
+    bool passed = true;
+    launch_wizard::FirstBootState state;
+
+    // Factory first boot: marker present, account unconfigured -> wizard.
+    state.factory_marker = true;
+    passed &= expect_wizard(true, state, "factory unconfigured");
+
+    // Imager-provisioned device: factory marker still present, but the user
+    // already has a password -> skip straight to the launcher (bug #227).
+    state.user_has_password = true;
+    passed &= expect_wizard(false, state, "factory imager-provisioned");
+
+    // Settings "Run Setup Wizard" re-arm always wins, even when configured.
+    state.rearm_marker = true;
+    passed &= expect_wizard(true, state, "re-arm on configured device");
+
+    // No markers at all: fall back to the legacy piwiz/lightdm signal.
+    state = {};
+    passed &= expect_wizard(false, state, "no markers");
+    state.legacy_piwiz_active = true;
+    passed &= expect_wizard(true, state, "legacy piwiz");
+    state.user_has_password = true;
+    passed &= expect_wizard(true, state, "legacy piwiz ignores password");
+
+    // Keyboard guide: needs both the marker and the installed binary; a
+    // missing binary keeps the marker for a later boot.
+    passed &= launch_wizard::should_run_keyboard_guide(true, true);
+    passed &= !launch_wizard::should_run_keyboard_guide(true, false);
+    passed &= !launch_wizard::should_run_keyboard_guide(false, true);
+    passed &= !launch_wizard::should_run_keyboard_guide(false, false);
+
+    if (!passed)
+        std::cerr << "first boot policy tests failed\n";
+    return passed;
+}

--- a/projects/LaunchWizard/tests/test_manual_datetime_validation.cpp
+++ b/projects/LaunchWizard/tests/test_manual_datetime_validation.cpp
@@ -8,6 +8,7 @@ bool test_service_handoff();
 bool test_command_runner();
 bool test_account_migration();
 bool test_apply_checkpoint();
+bool test_first_boot_policy();
 
 int main()
 {
@@ -42,5 +43,6 @@ int main()
     passed &= test_command_runner();
     passed &= test_account_migration();
     passed &= test_apply_checkpoint();
+    passed &= test_first_boot_policy();
     return passed ? 0 : 1;
 }

--- a/scripts/debian_packager.py
+++ b/scripts/debian_packager.py
@@ -199,6 +199,9 @@ def _control_text(config: PackageConfig) -> str:
     }
     if config.app_name == APP_NAME and config.package_name == PACKAGE_NAME:
         fields["X-CardputerZero-Update-ABI"] = LAUNCHER_UPDATE_ABI
+        # The user service pre-creates XDG folders (Music, Pictures, ...) via
+        # xdg-user-dirs-update; without a desktop session nothing else does.
+        fields["Depends"] = "xdg-user-dirs"
     return "".join(f"{key}: {value}\n" for key, value in fields.items())
 
 
@@ -622,6 +625,7 @@ After=pipewire-pulse.service
 Wants=pipewire-pulse.service
 
 [Service]
+ExecStartPre=-/usr/bin/xdg-user-dirs-update
 ExecStart=/{_posix_path(config.bin_path / config.bin_name)}
 WorkingDirectory=/{_posix_path(config.install_prefix)}
 Restart={config.service_restart}


### PR DESCRIPTION
## Summary

对应缺陷表 #227、#222，以及新增的开机键盘引导需求（放在开机引导之前，且无论 OOBE 是否跳过都恰好出现一次）。

### #227 开机引导逻辑
- `should_run()` 区分两个标记的语义：
  - `/var/lib/LaunchWizard/run-oobe`（pi-gen 出厂标记）：仅当 UID 1000 用户**没有真实密码**时才进 OOBE；Imager 刷卡时配置过用户名密码的设备直接跳过并清理标记
  - `/var/lib/applaunch/run-oobe`（设置里"Run Setup Wizard"）：保持无条件进引导
- 跳过路径（`finish_configured_system`）交棒 APPLaunch 后删除残留标记
- 决策逻辑抽成纯函数模块 `first_boot_policy`，附单元测试

### 键盘引导（Keyboard-Guide）
- LaunchWizard 在 OOBE 判定前消费 `/var/lib/LaunchWizard/run-keyboard-guide` 标记，用 `posix_spawn` + 阻塞 `waitpid` 运行 `M5CardputerZero-Keyboard-Guide`（继承 stdio 进 journald；不用 `run_command()` 是因为它有 30s 超时、输出捕获缓冲和 20ms 忙轮询，不适合分钟级交互应用）
- **exec 前删标记 + sync**：引导挂死后断电重启也不会陷入首启死循环
- 二进制缺失则保留标记并跳过，不阻塞开机

### #222 默认目录缺失
- APPLaunch 用户服务加 `ExecStartPre=-/usr/bin/xdg-user-dirs-update`，开机前补建 Music/Pictures 等 XDG 目录（产品禁用了 lightdm，桌面会话的钩子永远不会跑）
- applaunch deb 增加 `Depends: xdg-user-dirs`

## Test plan
- [x] `launch_wizard_core_tests` 全过（Linux CI 镜像，含新增 `test_first_boot_policy`）
- [x] LaunchWizard scons 交叉编译通过（Docker arm64）
- [x] `test_adb_packaging.py` / `test_updater_packaging.py` 全过（Linux）
- [ ] 实机验证三条路径（Imager 已配置跳过 / 纯净烧录进引导 / 设置重跑）

配套：pi-gen 侧标记与包安装见 CardputerZero/pi-gen 对应 PR；Keyboard-Guide 已 fork 到 org 并发布 v0.1.0（deb 附件）。

Made with [Cursor](https://cursor.com)