### PR TITLE
Fix LoRa initialization and long-message transmission

### DIFF
--- a/ext_components/cp0_lvgl/src/cp0/cp0_lora_runtime_policy.cpp
+++ b/ext_components/cp0_lvgl/src/cp0/cp0_lora_runtime_policy.cpp
@@ -1,5 +1,7 @@
 #include "cp0_lora_runtime_policy.hpp"
 
+#include <limits>
+
 namespace cp0_lora_runtime_policy {
 namespace {
 
@@ -8,21 +10,31 @@ bool interval_elapsed(uint64_t start_ms, uint64_t now_ms, uint64_t interval_ms)
     return now_ms >= start_ms && now_ms - start_ms >= interval_ms;
 }
 
-} // namespace
+}  // namespace
 
-bool should_timeout_transmit(bool initialized, bool tx_in_progress,
-                             bool radio_available, uint64_t tx_start_ms,
-                             uint64_t now_ms)
+uint64_t tx_timeout_for_airtime_us(uint64_t airtime_us) noexcept
+{
+    if (airtime_us == 0) return TX_TIMEOUT_MS;
+
+    const uint64_t airtime_ms = airtime_us / 1000 + (airtime_us % 1000 != 0 ? 1 : 0);
+    const uint64_t guard_ms   = airtime_ms / 2;
+    const uint64_t max_value  = std::numeric_limits<uint64_t>::max();
+    if (airtime_ms > max_value - guard_ms - TX_AIRTIME_GUARD_MS) return max_value;
+
+    const uint64_t guarded = airtime_ms + guard_ms + TX_AIRTIME_GUARD_MS;
+    return guarded > TX_TIMEOUT_MS ? guarded : TX_TIMEOUT_MS;
+}
+
+bool should_timeout_transmit(bool initialized, bool tx_in_progress, bool radio_available, uint64_t tx_start_ms,
+                             uint64_t now_ms, uint64_t timeout_ms)
 {
     return initialized && tx_in_progress && radio_available && tx_start_ms != 0 &&
-           interval_elapsed(tx_start_ms, now_ms, TX_TIMEOUT_MS);
+           interval_elapsed(tx_start_ms, now_ms, timeout_ms == 0 ? TX_TIMEOUT_MS : timeout_ms);
 }
 
-bool should_send_demo(bool initialized, bool tx_mode, bool tx_in_progress,
-                      uint64_t last_auto_tx_ms, uint64_t now_ms)
+bool should_send_demo(bool initialized, bool tx_mode, bool tx_in_progress, uint64_t last_auto_tx_ms, uint64_t now_ms)
 {
-    return initialized && tx_mode && !tx_in_progress &&
-           interval_elapsed(last_auto_tx_ms, now_ms, AUTO_TX_INTERVAL_MS);
+    return initialized && tx_mode && !tx_in_progress && interval_elapsed(last_auto_tx_ms, now_ms, AUTO_TX_INTERVAL_MS);
 }
 
-} // namespace cp0_lora_runtime_policy
+}  // namespace cp0_lora_runtime_policy

--- a/ext_components/cp0_lvgl/src/cp0/cp0_lora_runtime_policy.hpp
+++ b/ext_components/cp0_lvgl/src/cp0/cp0_lora_runtime_policy.hpp
@@ -4,14 +4,18 @@
 
 namespace cp0_lora_runtime_policy {
 
-constexpr uint64_t TX_TIMEOUT_MS = 4000;
+constexpr uint64_t TX_TIMEOUT_MS       = 4000;
+constexpr uint64_t TX_AIRTIME_GUARD_MS = 1500;
 constexpr uint64_t AUTO_TX_INTERVAL_MS = 2000;
 
-bool should_timeout_transmit(bool initialized, bool tx_in_progress,
-                             bool radio_available, uint64_t tx_start_ms,
-                             uint64_t now_ms);
+// Return a watchdog interval long enough for the packet to finish in the air,
+// with margin for the scheduler and the radio state transition. Keep the
+// previous four-second minimum for short packets and unknown airtime.
+uint64_t tx_timeout_for_airtime_us(uint64_t airtime_us) noexcept;
 
-bool should_send_demo(bool initialized, bool tx_mode, bool tx_in_progress,
-                      uint64_t last_auto_tx_ms, uint64_t now_ms);
+bool should_timeout_transmit(bool initialized, bool tx_in_progress, bool radio_available, uint64_t tx_start_ms,
+                             uint64_t now_ms, uint64_t timeout_ms = TX_TIMEOUT_MS);
 
-} // namespace cp0_lora_runtime_policy
+bool should_send_demo(bool initialized, bool tx_mode, bool tx_in_progress, uint64_t last_auto_tx_ms, uint64_t now_ms);
+
+}  // namespace cp0_lora_runtime_policy

--- a/ext_components/cp0_lvgl/src/cp0/cp0_lvgl_lara.cpp
+++ b/ext_components/cp0_lvgl/src/cp0/cp0_lvgl_lara.cpp
@@ -35,15 +35,17 @@
 #include "hal/RPi/PiHal.h"
 #else
 class PiHal : public RadioLibHal {
-  public:
+public:
     PiHal(uint8_t spiChannel, uint32_t spiSpeed = 2000000, uint8_t spiDevice = 0, uint8_t gpioDevice = 0)
-      : RadioLibHal(0, 1, 0, 1, 1, 2),
-        _gpioDevice(gpioDevice),
-        _spiDevice(spiDevice),
-        _spiSpeed(spiSpeed),
-        _spiChannel(spiChannel) {}
+        : RadioLibHal(0, 1, 0, 1, 1, 2),
+          _gpioDevice(gpioDevice),
+          _spiDevice(spiDevice),
+          _spiSpeed(spiSpeed),
+          _spiChannel(spiChannel)
+    {
+    }
 
-  protected:
+protected:
     uint8_t _gpioDevice;
     uint8_t _spiDevice;
     uint32_t _spiSpeed;
@@ -55,44 +57,61 @@ namespace cp0_lora_backend {
 // ============================================================
 //  Hardware configuration and state
 // ============================================================
-struct LoraRuntimeState
-{
+struct LoraRuntimeState {
     cp0_lora::SpiDevice spi;
     Module *radio_module = nullptr;
-    SX1262 *radio = nullptr;
+    SX1262 *radio        = nullptr;
 
-    int power_gpio = 5;
-    int rst_gpio = 26;
-    int irq_gpio = 23;
-    int busy_gpio = 22;
-    int rst_fd = -1;
-    int busy_fd = -1;
-    int irq_fd = -1;
-    bool nss_manual = false;
+    int power_gpio         = 5;
+    int rst_gpio           = 26;
+    int irq_gpio           = 23;
+    int busy_gpio          = 22;
+    int rst_fd             = -1;
+    int busy_fd            = -1;
+    int irq_fd             = -1;
+    bool nss_manual        = false;
     bool irq_poll_fallback = true;
 
     volatile bool initialized = false;
-    bool hw_ready = false;
-    bool tx_mode = false;
-    bool selected_tx_mode = false;
-    bool tx_in_progress = false;
-    bool pending_rx_after_tx = false;
-    volatile bool rx_done = false;
-    volatile bool tx_done = false;
-    bool rx_event = false;
-    bool tx_event = false;
-    bool has_sent_message = false;
+    bool hw_ready             = false;
+    bool tx_mode              = false;
+    bool selected_tx_mode     = false;
+    bool tx_in_progress       = false;
+    bool pending_rx_after_tx  = false;
+    volatile bool rx_done     = false;
+    volatile bool tx_done     = false;
+    bool rx_event             = false;
+    bool tx_event             = false;
+    bool has_sent_message     = false;
 
-    uint32_t tx_counter = 0;
-    uint64_t tx_start_ms = 0;
+    uint32_t tx_counter      = 0;
+    uint64_t tx_start_ms     = 0;
+    uint64_t tx_timeout_ms   = cp0_lora_runtime_policy::TX_TIMEOUT_MS;
     uint64_t last_auto_tx_ms = 0;
-    float last_rssi = 0.0f;
-    float last_snr = 0.0f;
-    char last_rx[128] = {};
-    char last_tx[128] = "Hello from M5 LoRa-1262";
-    char last_diag[256] = "idle";
-    char probe_summary[256] = "probe not started";
-    char probe_display[128] = "SPI: probing...";
+    float last_rssi          = 0.0f;
+    float last_snr           = 0.0f;
+    char last_rx[128]        = {};
+    char last_tx[128]        = "Hello from M5 LoRa-1262";
+    char last_diag[256]      = "idle";
+    char probe_summary[256]  = "probe not started";
+    char probe_display[128]  = "SPI: probing...";
+
+    void reset_runtime_flags()
+    {
+        initialized         = false;
+        hw_ready            = false;
+        tx_mode             = false;
+        selected_tx_mode    = false;
+        tx_in_progress      = false;
+        pending_rx_after_tx = false;
+        rx_done             = false;
+        tx_done             = false;
+        rx_event            = false;
+        tx_event            = false;
+        tx_start_ms         = 0;
+        tx_timeout_ms       = cp0_lora_runtime_policy::TX_TIMEOUT_MS;
+        last_auto_tx_ms     = 0;
+    }
 
     void reset_radio()
     {
@@ -136,6 +155,14 @@ static const char *lora_radiolib_status_text(int16_t state);
 static bool lora_send_text_packet(const char *payload);
 static void lora_init_hardware(void);
 
+static void lora_release_hardware()
+{
+    g_lora.reset_radio();
+    g_lora.spi.close();
+    g_lora.close_gpio_lines();
+    cp0_lora_hat_power_controller::shutdown();
+    g_lora.reset_runtime_flags();
+}
 
 static bool lora_spi_transfer(const uint8_t *tx, uint8_t *rx, size_t len)
 {
@@ -144,17 +171,15 @@ static bool lora_spi_transfer(const uint8_t *tx, uint8_t *rx, size_t len)
 
 static bool lora_open_runtime_spi(void)
 {
-    if (g_lora.spi.open())
-        return true;
-    snprintf(g_lora.last_diag, sizeof(g_lora.last_diag),
-             "runtime SPI open/config failed on %s", g_lora.spi.path());
+    if (g_lora.spi.open()) return true;
+    snprintf(g_lora.last_diag, sizeof(g_lora.last_diag), "runtime SPI open/config failed on %s", g_lora.spi.path());
     return false;
 }
 
 static bool sx1262_wait_while_busy(unsigned int timeout_ms)
 {
     const unsigned int sleep_us = 1000;
-    unsigned int waited_ms = 0;
+    unsigned int waited_ms      = 0;
     while (waited_ms < timeout_ms) {
         int busy = gpio_get_value_any(g_lora.busy_gpio, g_lora.busy_fd);
         if (busy < 0) return false;
@@ -186,14 +211,14 @@ static bool sx1262_get_status_raw(uint8_t *status)
 
 static bool probe_lora_spi_device(void)
 {
-    const char *spi_env = getenv("LORA_SPI_DEV");
-    char candidates[16][64] = {{0}};
-    const size_t candidate_count =
-        cp0_lora_device_discovery::collect_spi_candidates(candidates, 16, spi_env);
-    char summary[256] = {0};
+    const char *spi_env          = getenv("LORA_SPI_DEV");
+    char candidates[16][64]      = {{0}};
+    const size_t candidate_count = cp0_lora_device_discovery::collect_spi_candidates(candidates, 16, spi_env);
+    char summary[256]            = {0};
 
     if (access("/dev", F_OK) != 0) {
-        snprintf(g_lora.last_diag, sizeof(g_lora.last_diag), "Linux /dev not available; LoRa SPI HAL requires Raspberry Pi Linux runtime");
+        snprintf(g_lora.last_diag, sizeof(g_lora.last_diag),
+                 "Linux /dev not available; LoRa SPI HAL requires Raspberry Pi Linux runtime");
         snprintf(g_lora.probe_summary, sizeof(g_lora.probe_summary), "no /dev directory visible");
         snprintf(g_lora.probe_display, sizeof(g_lora.probe_display), "SPI: /dev unavailable");
         return false;
@@ -213,8 +238,8 @@ static bool probe_lora_spi_device(void)
         strncat(summary, dev, sizeof(summary) - strlen(summary) - 1);
     }
     if (spi_env && spi_env[0]) {
-        snprintf(g_lora.probe_summary, sizeof(g_lora.probe_summary), "probe order: %.96s%s%.128s",
-                 spi_env, summary[0] ? ", " : "", summary);
+        snprintf(g_lora.probe_summary, sizeof(g_lora.probe_summary), "probe order: %.96s%s%.128s", spi_env,
+                 summary[0] ? ", " : "", summary);
         snprintf(g_lora.probe_display, sizeof(g_lora.probe_display), "Try: %.96s -> 0.1 -> 0.0", spi_env);
     } else {
         snprintf(g_lora.probe_summary, sizeof(g_lora.probe_summary), "probe order: %.224s", summary);
@@ -224,9 +249,10 @@ static bool probe_lora_spi_device(void)
     auto try_probe = [](const char *dev) -> bool {
         if (dev == NULL || dev[0] == '\0' || access(dev, F_OK) != 0) return false;
         g_lora.spi.set_path(dev);
-        g_lora.nss_manual = false;
+        g_lora.nss_manual    = false;
         const char *spi_path = g_lora.spi.path();
-        const char *cs_name = strstr(spi_path, "spidev0.1") ? "SPI0-CE1" : (strstr(spi_path, "spidev0.0") ? "SPI0-CE0" : "non-SPI0");
+        const char *cs_name =
+            strstr(spi_path, "spidev0.1") ? "SPI0-CE1" : (strstr(spi_path, "spidev0.0") ? "SPI0-CE0" : "non-SPI0");
         SLOGI("LoRa probe: trying %s [%s] (cs=hw-auto)", spi_path, cs_name);
         g_lora.initialized = false;
         g_lora.spi.close();
@@ -250,7 +276,8 @@ static bool probe_lora_spi_device(void)
             return false;
         }
         SLOGI("LoRa probe: %s [%s] (cs=hw-auto) status=0x%02X", spi_path, cs_name, status);
-        snprintf(g_lora.last_diag, sizeof(g_lora.last_diag), "probe ok on %s[%s] cs=hw-auto status=0x%02X", spi_path, cs_name, status);
+        snprintf(g_lora.last_diag, sizeof(g_lora.last_diag), "probe ok on %s[%s] cs=hw-auto status=0x%02X", spi_path,
+                 cs_name, status);
         snprintf(g_lora.probe_display, sizeof(g_lora.probe_display), "FOUND: %s (%s)", spi_path, cs_name);
         return true;
     };
@@ -259,38 +286,42 @@ static bool probe_lora_spi_device(void)
     for (size_t i = 0; i < candidate_count; ++i) {
         if (try_probe(candidates[i])) return true;
     }
-    snprintf(g_lora.last_diag, sizeof(g_lora.last_diag), "all SPI buses probed, no SX1262 response (%.192s)", g_lora.probe_summary);
+    snprintf(g_lora.last_diag, sizeof(g_lora.last_diag), "all SPI buses probed, no SX1262 response (%.192s)",
+             g_lora.probe_summary);
     snprintf(g_lora.probe_display, sizeof(g_lora.probe_display), "NOT FOUND: tried 0.1 and 0.0");
     return false;
 }
 
 static void resolve_lora_spi_device(void)
 {
-    const char *spi_env = getenv("LORA_SPI_DEV");
-    char candidates[16][64] = {{0}};
-    const size_t candidate_count =
-        cp0_lora_device_discovery::collect_spi_candidates(candidates, 16, spi_env);
+    const char *spi_env          = getenv("LORA_SPI_DEV");
+    char candidates[16][64]      = {{0}};
+    const size_t candidate_count = cp0_lora_device_discovery::collect_spi_candidates(candidates, 16, spi_env);
     if (spi_env != NULL && spi_env[0] != '\0' && access(spi_env, F_OK) == 0) {
-        g_lora.spi.set_path(spi_env); return;
+        g_lora.spi.set_path(spi_env);
+        return;
     }
     for (size_t i = 0; i < candidate_count; ++i) {
         if (access(candidates[i], F_OK) == 0) {
-            g_lora.spi.set_path(candidates[i]); return;
+            g_lora.spi.set_path(candidates[i]);
+            return;
         }
     }
     g_lora.spi.set_path(spi_env && spi_env[0] ? spi_env : "/dev/spidev0.1");
 }
-
 
 // ============================================================
 //  RadioLib HAL / Module / TX/RX logic
 // ============================================================
 
 class LinuxRadioLibHal : public PiHal {
-  public:
-    LinuxRadioLibHal() : PiHal(0, 2000000, 0, 0) {}
+public:
+    LinuxRadioLibHal() : PiHal(0, 2000000, 0, 0)
+    {
+    }
 
-    void pinMode(uint32_t pin, uint32_t mode) override {
+    void pinMode(uint32_t pin, uint32_t mode) override
+    {
         if (pin == RADIOLIB_NC) return;
         if (mode == GpioModeOutput) {
             if (pin == (uint32_t)g_lora.rst_gpio) {
@@ -303,14 +334,16 @@ class LinuxRadioLibHal : public PiHal {
         }
     }
 
-    void digitalWrite(uint32_t pin, uint32_t value) override {
+    void digitalWrite(uint32_t pin, uint32_t value) override
+    {
         if (pin == RADIOLIB_NC) return;
         int line_fd = -1;
         if (pin == (uint32_t)g_lora.rst_gpio) line_fd = g_lora.rst_fd;
         (void)gpio_set_value_any((int)pin, line_fd, value ? 1 : 0);
     }
 
-    uint32_t digitalRead(uint32_t pin) override {
+    uint32_t digitalRead(uint32_t pin) override
+    {
         if (pin == RADIOLIB_NC) return 0;
         int line_fd = -1;
         if (pin == (uint32_t)g_lora.busy_gpio) line_fd = g_lora.busy_fd;
@@ -318,38 +351,63 @@ class LinuxRadioLibHal : public PiHal {
         return value > 0 ? 1U : 0U;
     }
 
-    void attachInterrupt(uint32_t, void (*)(void), uint32_t) override {}
-    void detachInterrupt(uint32_t) override {}
-    void delay(RadioLibTime_t ms) override { usleep((useconds_t)(ms * 1000)); }
-    void delayMicroseconds(RadioLibTime_t us) override { usleep((useconds_t)us); }
-    RadioLibTime_t millis() override { return (RadioLibTime_t)get_monotonic_ms(); }
-    RadioLibTime_t micros() override {
+    void attachInterrupt(uint32_t, void (*)(void), uint32_t) override
+    {
+    }
+    void detachInterrupt(uint32_t) override
+    {
+    }
+    void delay(RadioLibTime_t ms) override
+    {
+        usleep((useconds_t)(ms * 1000));
+    }
+    void delayMicroseconds(RadioLibTime_t us) override
+    {
+        usleep((useconds_t)us);
+    }
+    RadioLibTime_t millis() override
+    {
+        return (RadioLibTime_t)get_monotonic_ms();
+    }
+    RadioLibTime_t micros() override
+    {
         struct timespec ts;
         clock_gettime(CLOCK_MONOTONIC, &ts);
         return (RadioLibTime_t)ts.tv_sec * 1000000ULL + (RadioLibTime_t)ts.tv_nsec / 1000ULL;
     }
-    long pulseIn(uint32_t pin, uint32_t state, RadioLibTime_t timeout) override {
+    long pulseIn(uint32_t pin, uint32_t state, RadioLibTime_t timeout) override
+    {
         RadioLibTime_t start = micros();
         while (micros() - start < timeout) {
             if (digitalRead(pin) == state) {
                 RadioLibTime_t pulse_start = micros();
-                while (micros() - start < timeout && digitalRead(pin) == state) {}
+                while (micros() - start < timeout && digitalRead(pin) == state) {
+                }
                 return (long)(micros() - pulse_start);
             }
         }
         return 0;
     }
-    void spiBegin() override {}
-    void spiBeginTransaction() override {}
-    void spiTransfer(uint8_t *out, size_t len, uint8_t *in) override {
+    void spiBegin() override
+    {
+    }
+    void spiBeginTransaction() override
+    {
+    }
+    void spiTransfer(uint8_t *out, size_t len, uint8_t *in) override
+    {
         uint8_t dummy[512] = {0};
-        uint8_t *tx = out ? out : dummy;
-        uint8_t *rx = in ? in : dummy;
+        uint8_t *tx        = out ? out : dummy;
+        uint8_t *rx        = in ? in : dummy;
         if (len > sizeof(dummy)) len = sizeof(dummy);
         (void)lora_spi_transfer(tx, rx, len);
     }
-    void spiEndTransaction() override {}
-    void spiEnd() override {}
+    void spiEndTransaction() override
+    {
+    }
+    void spiEnd() override
+    {
+    }
 };
 
 static LinuxRadioLibHal g_lora_radio_hal;
@@ -363,25 +421,47 @@ static uint64_t get_monotonic_ms(void)
 
 static void lora_set_diag_step(const char *step, int code, const char *detail)
 {
-    snprintf(g_lora.last_diag, sizeof(g_lora.last_diag), "%s%s%s | rc=%d",
-             step ? step : "diag", (detail && detail[0]) ? " | " : "", (detail && detail[0]) ? detail : "", code);
+    char detail_copy[sizeof(g_lora.last_diag)] = {};
+    if (detail && detail[0]) snprintf(detail_copy, sizeof(detail_copy), "%s", detail);
+    snprintf(g_lora.last_diag, sizeof(g_lora.last_diag), "%s%s%s | rc=%d", step ? step : "diag",
+             detail_copy[0] ? " | " : "", detail_copy, code);
     SLOGI("LoRa diag: %s", g_lora.last_diag);
 }
 
 static const char *lora_radiolib_status_text(int16_t state)
 {
     switch (state) {
-    case RADIOLIB_ERR_NONE: return "ok";
-    case RADIOLIB_ERR_CHIP_NOT_FOUND: return "chip_not_found";
-    case RADIOLIB_ERR_TX_TIMEOUT: return "tx_timeout";
-    case RADIOLIB_ERR_RX_TIMEOUT: return "rx_timeout";
-    case RADIOLIB_ERR_CRC_MISMATCH: return "crc_mismatch";
-    case RADIOLIB_ERR_SPI_WRITE_FAILED: return "spi_write_failed";
-    case RADIOLIB_ERR_SPI_CMD_TIMEOUT: return "spi_cmd_timeout";
-    case RADIOLIB_ERR_SPI_CMD_INVALID: return "spi_cmd_invalid";
-    case RADIOLIB_ERR_SPI_CMD_FAILED: return "spi_cmd_failed";
-    default: return "radiolib_err";
+        case RADIOLIB_ERR_NONE:
+            return "ok";
+        case RADIOLIB_ERR_CHIP_NOT_FOUND:
+            return "chip_not_found";
+        case RADIOLIB_ERR_TX_TIMEOUT:
+            return "tx_timeout";
+        case RADIOLIB_ERR_RX_TIMEOUT:
+            return "rx_timeout";
+        case RADIOLIB_ERR_CRC_MISMATCH:
+            return "crc_mismatch";
+        case RADIOLIB_ERR_SPI_WRITE_FAILED:
+            return "spi_write_failed";
+        case RADIOLIB_ERR_SPI_CMD_TIMEOUT:
+            return "spi_cmd_timeout";
+        case RADIOLIB_ERR_SPI_CMD_INVALID:
+            return "spi_cmd_invalid";
+        case RADIOLIB_ERR_SPI_CMD_FAILED:
+            return "spi_cmd_failed";
+        default:
+            return "radiolib_err";
     }
+}
+
+static uint64_t lora_tx_timeout_for_payload(size_t payload_length)
+{
+    const uint64_t airtime_us =
+        g_lora.radio == nullptr ? 0 : static_cast<uint64_t>(g_lora.radio->getTimeOnAir(payload_length));
+    const uint64_t timeout_ms = cp0_lora_runtime_policy::tx_timeout_for_airtime_us(airtime_us);
+    SLOGI("LoRa TX: payload=%zu airtime=%lluus watchdog=%llums", payload_length,
+          static_cast<unsigned long long>(airtime_us), static_cast<unsigned long long>(timeout_ms));
+    return timeout_ms;
 }
 
 static void lora_capture_device_errors(const char *stage, uint16_t irq_status)
@@ -400,18 +480,23 @@ static bool lora_send_text_packet(const char *payload)
     if (payload == NULL || payload[0] == '\0') return false;
     if (g_lora.tx_in_progress) return false;
     snprintf(g_lora.last_tx, sizeof(g_lora.last_tx), "%s", payload);
-    g_lora.has_sent_message = true;
-    g_lora.tx_done = false;
-    g_lora.rx_done = false;
+    g_lora.has_sent_message    = true;
+    g_lora.tx_done             = false;
+    g_lora.rx_done             = false;
     g_lora.pending_rx_after_tx = true;
-    g_lora.tx_mode = false;
-    g_lora.selected_tx_mode = false;
+    g_lora.tx_mode             = false;
+    g_lora.selected_tx_mode    = false;
     (void)g_lora.radio->standby();
-    int16_t state = g_lora.radio->startTransmit((uint8_t *)g_lora.last_tx, strlen(g_lora.last_tx));
+    const size_t payload_length = strlen(g_lora.last_tx);
+    g_lora.tx_timeout_ms        = lora_tx_timeout_for_payload(payload_length);
+    int16_t state               = g_lora.radio->startTransmit((uint8_t *)g_lora.last_tx, payload_length);
     if (state != RADIOLIB_ERR_NONE) {
-        g_lora.tx_in_progress = false;
+        g_lora.tx_in_progress      = false;
+        g_lora.tx_start_ms         = 0;
         g_lora.pending_rx_after_tx = false;
+        g_lora.tx_timeout_ms       = cp0_lora_runtime_policy::TX_TIMEOUT_MS;
         SLOGI("LoRa TX: startTransmit failed rc=%d(%s)", (int)state, lora_radiolib_status_text(state));
+        lora_start_receive_mode();
         return false;
     }
     g_lora.tx_in_progress = true;
@@ -425,13 +510,17 @@ static void lora_send_demo_packet(void)
     if (!g_lora.initialized || g_lora.radio == NULL) return;
     if (!g_lora.tx_mode) return;
     snprintf(g_lora.last_tx, sizeof(g_lora.last_tx), "Hello from M5 LoRa-1262 #%lu", (unsigned long)g_lora.tx_counter);
-    g_lora.has_sent_message = true;
-    g_lora.pending_rx_after_tx = false;
-    g_lora.tx_done = false;
-    g_lora.rx_done = false;
-    int16_t state = g_lora.radio->startTransmit((uint8_t *)g_lora.last_tx, strlen(g_lora.last_tx));
+    g_lora.has_sent_message     = true;
+    g_lora.pending_rx_after_tx  = false;
+    g_lora.tx_done              = false;
+    g_lora.rx_done              = false;
+    const size_t payload_length = strlen(g_lora.last_tx);
+    g_lora.tx_timeout_ms        = lora_tx_timeout_for_payload(payload_length);
+    int16_t state               = g_lora.radio->startTransmit((uint8_t *)g_lora.last_tx, payload_length);
     if (state != RADIOLIB_ERR_NONE) {
         g_lora.tx_in_progress = false;
+        g_lora.tx_start_ms    = 0;
+        g_lora.tx_timeout_ms  = cp0_lora_runtime_policy::TX_TIMEOUT_MS;
         SLOGI("LoRa TX: demo startTransmit failed rc=%d(%s)", (int)state, lora_radiolib_status_text(state));
         return;
     }
@@ -452,14 +541,15 @@ static void lora_start_receive_mode(void)
         g_lora.pending_rx_after_tx = true;
         return;
     }
-    g_lora.tx_mode = false;
-    g_lora.selected_tx_mode = false;
+    g_lora.tx_mode             = false;
+    g_lora.selected_tx_mode    = false;
     g_lora.pending_rx_after_tx = false;
     SLOGI("LoRa RX: startReceive()");
     int16_t state = g_lora.radio->startReceive();
     SLOGI("LoRa RX: startReceive rc=%d(%s)", (int)state, lora_radiolib_status_text(state));
     if (state != RADIOLIB_ERR_NONE) {
-        snprintf(g_lora.last_diag, sizeof(g_lora.last_diag), "startReceive rc=%d(%s)", (int)state, lora_radiolib_status_text(state));
+        snprintf(g_lora.last_diag, sizeof(g_lora.last_diag), "startReceive rc=%d(%s)", (int)state,
+                 lora_radiolib_status_text(state));
     }
 }
 
@@ -472,8 +562,8 @@ static void lora_apply_mode(bool tx_mode)
     }
     if (tx_mode) {
         g_lora.pending_rx_after_tx = false;
-        g_lora.tx_mode = true;
-        g_lora.last_auto_tx_ms = get_monotonic_ms();
+        g_lora.tx_mode             = true;
+        g_lora.last_auto_tx_ms     = get_monotonic_ms();
         if (g_lora.tx_in_progress) {
             SLOGI("LoRa mode: TX already in progress");
             return;
@@ -491,8 +581,8 @@ static void lora_apply_mode(bool tx_mode)
             return;
         }
         g_lora.pending_rx_after_tx = false;
-        g_lora.tx_mode = false;
-        g_lora.last_auto_tx_ms = get_monotonic_ms();
+        g_lora.tx_mode             = false;
+        g_lora.last_auto_tx_ms     = get_monotonic_ms();
         lora_start_receive_mode();
     }
 }
@@ -505,25 +595,29 @@ static void lora_service_irq_once(void)
     if (!g_lora.irq_poll_fallback && g_lora.irq_fd >= 0) {
         struct pollfd pfd;
         memset(&pfd, 0, sizeof(pfd));
-        pfd.fd = g_lora.irq_fd;
+        pfd.fd     = g_lora.irq_fd;
         pfd.events = POLLIN | POLLPRI;
         if (poll(&pfd, 1, 0) > 0 && (pfd.revents & (POLLIN | POLLPRI))) {
             irq_event = true;
 #if HAS_LINUX_GPIO_CDEV
             struct gpioevent_data event_data;
-            while (read(g_lora.irq_fd, &event_data, sizeof(event_data)) == (ssize_t)sizeof(event_data)) {}
+            while (read(g_lora.irq_fd, &event_data, sizeof(event_data)) == (ssize_t)sizeof(event_data)) {
+            }
 #else
             char value_buf[8];
             lseek(g_lora.irq_fd, 0, SEEK_SET);
-            while (read(g_lora.irq_fd, value_buf, sizeof(value_buf)) > 0) { lseek(g_lora.irq_fd, 0, SEEK_SET); break; }
+            while (read(g_lora.irq_fd, value_buf, sizeof(value_buf)) > 0) {
+                lseek(g_lora.irq_fd, 0, SEEK_SET);
+                break;
+            }
 #endif
         }
     }
 
     uint32_t irq_flags = g_lora.radio->getIrqFlags();
     if (irq_flags != RADIOLIB_SX126X_IRQ_NONE || irq_event) {
-        SLOGI("LoRa IRQ: event=%d flags=0x%08lX tx_in_progress=%d tx_mode=%d",
-               irq_event ? 1 : 0, (unsigned long)irq_flags, g_lora.tx_in_progress ? 1 : 0, g_lora.tx_mode ? 1 : 0);
+        SLOGI("LoRa IRQ: event=%d flags=0x%08lX tx_in_progress=%d tx_mode=%d", irq_event ? 1 : 0,
+              (unsigned long)irq_flags, g_lora.tx_in_progress ? 1 : 0, g_lora.tx_mode ? 1 : 0);
     }
     if (!irq_event && irq_flags == RADIOLIB_SX126X_IRQ_NONE) return;
 
@@ -534,11 +628,17 @@ static void lora_service_irq_once(void)
                 g_lora.tx_done = true;
             } else {
                 g_lora.tx_in_progress = false;
+                g_lora.tx_start_ms    = 0;
+                g_lora.tx_timeout_ms  = cp0_lora_runtime_policy::TX_TIMEOUT_MS;
+                snprintf(g_lora.last_diag, sizeof(g_lora.last_diag), "finishTransmit rc=%d(%s)", (int)state,
+                         lora_radiolib_status_text(state));
                 SLOGI("LoRa TX: finishTransmit failed rc=%d(%s)", (int)state, lora_radiolib_status_text(state));
+                if (g_lora.pending_rx_after_tx || !g_lora.tx_mode) lora_start_receive_mode();
             }
         } else if (irq_flags & RADIOLIB_SX126X_IRQ_TIMEOUT) {
             g_lora.tx_in_progress = false;
-            g_lora.tx_start_ms = 0;
+            g_lora.tx_start_ms    = 0;
+            g_lora.tx_timeout_ms  = cp0_lora_runtime_policy::TX_TIMEOUT_MS;
             lora_capture_device_errors("TX irq timeout", 0);
             if (g_lora.pending_rx_after_tx || !g_lora.tx_mode) lora_start_receive_mode();
         }
@@ -547,21 +647,23 @@ static void lora_service_irq_once(void)
 
     if (irq_flags & RADIOLIB_SX126X_IRQ_RX_DONE) {
         uint8_t rx_buf[sizeof(g_lora.last_rx)] = {0};
-        int16_t state = g_lora.radio->readData(rx_buf, sizeof(g_lora.last_rx) - 1);
+        int16_t state                          = g_lora.radio->readData(rx_buf, sizeof(g_lora.last_rx) - 1);
         SLOGI("LoRa RX: readData rc=%d(%s)", (int)state, lora_radiolib_status_text(state));
         if (state == RADIOLIB_ERR_NONE) {
             memcpy(g_lora.last_rx, rx_buf, sizeof(g_lora.last_rx));
             g_lora.last_rx[sizeof(g_lora.last_rx) - 1] = '\0';
-            g_lora.last_rssi = g_lora.radio->getRSSI();
-            g_lora.last_snr = g_lora.radio->getSNR();
-            g_lora.rx_done = true;
+            g_lora.last_rssi                           = g_lora.radio->getRSSI();
+            g_lora.last_snr                            = g_lora.radio->getSNR();
+            g_lora.rx_done                             = true;
             SLOGI("LoRa RX OK: '%s' RSSI=%.1f SNR=%.1f", g_lora.last_rx, g_lora.last_rssi, g_lora.last_snr);
         } else if (state != RADIOLIB_ERR_CRC_MISMATCH) {
-            snprintf(g_lora.last_diag, sizeof(g_lora.last_diag), "readData rc=%d(%s)", (int)state, lora_radiolib_status_text(state));
+            snprintf(g_lora.last_diag, sizeof(g_lora.last_diag), "readData rc=%d(%s)", (int)state,
+                     lora_radiolib_status_text(state));
         }
         if (!g_lora.tx_mode) lora_start_receive_mode();
     } else if (irq_flags & (RADIOLIB_SX126X_IRQ_CRC_ERR | RADIOLIB_SX126X_IRQ_HEADER_ERR)) {
-        snprintf(g_lora.last_diag, sizeof(g_lora.last_diag), "RX crc/header error irq=0x%04lX", (unsigned long)irq_flags);
+        snprintf(g_lora.last_diag, sizeof(g_lora.last_diag), "RX crc/header error irq=0x%04lX",
+                 (unsigned long)irq_flags);
         SLOGI("LoRa RX error: %s", g_lora.last_diag);
         if (!g_lora.tx_mode) lora_start_receive_mode();
     } else if (irq_flags & RADIOLIB_SX126X_IRQ_TIMEOUT) {
@@ -573,11 +675,12 @@ static void lora_service_irq_once(void)
 static void lora_check_tx_fallback(void)
 {
     uint64_t now_ms = get_monotonic_ms();
-    if (cp0_lora_runtime_policy::should_timeout_transmit(
-            g_lora.initialized, g_lora.tx_in_progress, g_lora.radio != NULL,
-            g_lora.tx_start_ms, now_ms)) {
-        g_lora.tx_in_progress = false;
-        g_lora.tx_start_ms = 0;
+    if (cp0_lora_runtime_policy::should_timeout_transmit(g_lora.initialized, g_lora.tx_in_progress,
+                                                         g_lora.radio != NULL, g_lora.tx_start_ms, now_ms,
+                                                         g_lora.tx_timeout_ms)) {
+        g_lora.tx_in_progress  = false;
+        g_lora.tx_start_ms     = 0;
+        g_lora.tx_timeout_ms   = cp0_lora_runtime_policy::TX_TIMEOUT_MS;
         g_lora.last_auto_tx_ms = now_ms;
         lora_capture_device_errors("TX timeout", 0);
         (void)g_lora.radio->standby();
@@ -592,28 +695,27 @@ static void lora_poll_hardware(void)
     lora_check_tx_fallback();
 
     if (g_lora.tx_done) {
-        g_lora.tx_done = false;
-        g_lora.tx_event = true;
+        g_lora.tx_done        = false;
+        g_lora.tx_event       = true;
         g_lora.tx_in_progress = false;
-        g_lora.tx_start_ms = 0;
+        g_lora.tx_start_ms    = 0;
+        g_lora.tx_timeout_ms  = cp0_lora_runtime_policy::TX_TIMEOUT_MS;
         if (g_lora.pending_rx_after_tx || !g_lora.tx_mode) {
             lora_start_receive_mode();
         }
     }
 
     if (g_lora.rx_done) {
-        g_lora.rx_done = false;
+        g_lora.rx_done  = false;
         g_lora.rx_event = true;
     }
 
     uint64_t now_ms = get_monotonic_ms();
-    if (cp0_lora_runtime_policy::should_send_demo(
-            g_lora.initialized, g_lora.tx_mode, g_lora.tx_in_progress,
-            g_lora.last_auto_tx_ms, now_ms)) {
+    if (cp0_lora_runtime_policy::should_send_demo(g_lora.initialized, g_lora.tx_mode, g_lora.tx_in_progress,
+                                                  g_lora.last_auto_tx_ms, now_ms)) {
         lora_send_demo_packet();
     }
 }
-
 
 // ============================================================
 //  Hardware initialization
@@ -621,7 +723,9 @@ static void lora_poll_hardware(void)
 
 static void lora_init_hardware(void)
 {
-    g_lora.reset_radio();
+    // A failed probe can leave SPI/GPIO handles allocated. Release all of
+    // them before retrying so entering the page again is deterministic.
+    lora_release_hardware();
 
     lora_set_diag_step("i2c_scan", 0, "scan 0x43 before LoRa init");
     if (cp0_lora_pi4io_controller::scan_and_initialize()) {
@@ -639,21 +743,27 @@ static void lora_init_hardware(void)
 
     lora_set_diag_step("reset_gpio_init", 0, "prepare rst pin");
     if (gpio_init_output_any("LORA_RST_CHIP", "LORA_RST_OFFSET", g_lora.rst_gpio, 1, &g_lora.rst_fd, "RST") < 0) {
-        g_lora.initialized = false; g_lora.hw_ready = false;
+        g_lora.initialized = false;
+        g_lora.hw_ready    = false;
         lora_set_diag_step("reset_gpio_init", 1, "rst gpio init failed");
+        lora_release_hardware();
         return;
     }
 
     if (gpio_init_input_any("LORA_BUSY_CHIP", "LORA_BUSY_OFFSET", g_lora.busy_gpio, &g_lora.busy_fd, "BUSY") < 0) {
-        g_lora.initialized = false; g_lora.hw_ready = false;
+        g_lora.initialized = false;
+        g_lora.hw_ready    = false;
         lora_set_diag_step("busy_gpio_init", 1, "busy gpio init failed");
+        lora_release_hardware();
         return;
     }
 
     lora_set_diag_step("hard_reset", 0, "toggle rst before probe");
     if (!sx1262_reset()) {
-        g_lora.initialized = false; g_lora.hw_ready = false;
+        g_lora.initialized = false;
+        g_lora.hw_ready    = false;
         lora_set_diag_step("hard_reset", 1, "rst/busy handshake failed");
+        lora_release_hardware();
         return;
     }
 
@@ -661,15 +771,19 @@ static void lora_init_hardware(void)
     resolve_lora_spi_device();
 
     if (!probe_lora_spi_device()) {
-        g_lora.initialized = false; g_lora.hw_ready = false;
+        g_lora.initialized = false;
+        g_lora.hw_ready    = false;
         lora_set_diag_step("probe_spi", 1, g_lora.last_diag);
+        lora_release_hardware();
         return;
     }
 
     lora_set_diag_step("pre_begin_prepare", 0, "reset again before RadioLib begin");
     if (!sx1262_reset()) {
-        g_lora.initialized = false; g_lora.hw_ready = false;
+        g_lora.initialized = false;
+        g_lora.hw_ready    = false;
         lora_set_diag_step("pre_begin_prepare", 1, "rst/busy handshake failed before RadioLib begin");
+        lora_release_hardware();
         return;
     }
 
@@ -684,75 +798,78 @@ static void lora_init_hardware(void)
 
     lora_set_diag_step("runtime_spi", 0, "open SPI for RadioLib runtime");
     if (!lora_open_runtime_spi()) {
-        g_lora.initialized = false; g_lora.hw_ready = false;
+        g_lora.initialized = false;
+        g_lora.hw_ready    = false;
         lora_set_diag_step("runtime_spi", 1, g_lora.last_diag);
+        lora_release_hardware();
         return;
     }
 
     lora_set_diag_step("radiolib_setup", 0, "create module");
-    g_lora.nss_manual = false;
-    g_lora.radio_module = new Module(&g_lora_radio_hal, RADIOLIB_NC,
-                                     (uint32_t)g_lora.irq_gpio, (uint32_t)g_lora.rst_gpio, (uint32_t)g_lora.busy_gpio);
-    g_lora.radio = new SX1262(g_lora.radio_module);
+    g_lora.nss_manual   = false;
+    g_lora.radio_module = new Module(&g_lora_radio_hal, RADIOLIB_NC, (uint32_t)g_lora.irq_gpio,
+                                     (uint32_t)g_lora.rst_gpio, (uint32_t)g_lora.busy_gpio);
+    g_lora.radio        = new SX1262(g_lora.radio_module);
 
     if (g_lora.radio_module == NULL || g_lora.radio == NULL) {
-        g_lora.initialized = false; g_lora.hw_ready = false;
+        g_lora.initialized = false;
+        g_lora.hw_ready    = false;
         lora_set_diag_step("radiolib_setup", 1, "allocation failed");
+        lora_release_hardware();
         return;
     }
 
     lora_set_diag_step("radiolib_begin", 0, "configure sx1262 via RadioLib");
-    int16_t state = g_lora.radio->begin(
-        868.0f,   // frequency MHz
-        125.0f,   // bandwidth kHz
-        12,       // spreading factor
-        5,        // coding rate 4/5
-        0x34,     // sync word
-        22,       // output power dBm
-        20,       // preamble length
-        3.0f,     // TCXO voltage
-        false
-    );
+    int16_t state = g_lora.radio->begin(868.0f,  // frequency MHz
+                                        125.0f,  // bandwidth kHz
+                                        12,      // spreading factor
+                                        5,       // coding rate 4/5
+                                        0x34,    // sync word
+                                        22,      // output power dBm
+                                        20,      // preamble length
+                                        3.0f,    // TCXO voltage
+                                        false);
 
     if (state != RADIOLIB_ERR_NONE) {
-        g_lora.initialized = false; g_lora.hw_ready = false;
-        snprintf(g_lora.last_diag, sizeof(g_lora.last_diag), "RadioLib begin rc=%d(%s)", (int)state, lora_radiolib_status_text(state));
+        g_lora.initialized = false;
+        g_lora.hw_ready    = false;
+        snprintf(g_lora.last_diag, sizeof(g_lora.last_diag), "RadioLib begin rc=%d(%s)", (int)state,
+                 lora_radiolib_status_text(state));
         SLOGI("LoRa init failed: rc=%d (%s)", (int)state, lora_radiolib_status_text(state));
         lora_set_diag_step("radiolib_begin", state, g_lora.last_diag);
+        lora_release_hardware();
         return;
     }
 
     (void)g_lora.radio->setCurrentLimit(140);
     (void)g_lora.radio->setDio2AsRfSwitch(true);
 
-    g_lora.initialized = true;
-    g_lora.hw_ready = true;
-    g_lora.tx_mode = false;
-    g_lora.selected_tx_mode = false;
-    g_lora.tx_in_progress = false;
+    g_lora.initialized         = true;
+    g_lora.hw_ready            = true;
+    g_lora.tx_mode             = false;
+    g_lora.selected_tx_mode    = false;
+    g_lora.tx_in_progress      = false;
     g_lora.pending_rx_after_tx = false;
-    g_lora.tx_start_ms = 0;
-    g_lora.last_auto_tx_ms = get_monotonic_ms();
+    g_lora.tx_start_ms         = 0;
+    g_lora.tx_timeout_ms       = cp0_lora_runtime_policy::TX_TIMEOUT_MS;
+    g_lora.last_auto_tx_ms     = get_monotonic_ms();
 
     lora_set_diag_step("ready", 0, "LoRa init finished");
     SLOGI("LoRa: init done, auto enter RX");
     lora_start_receive_mode();
 }
 
-
-
-
 void get_info(cp0_lora_info_t *info, bool drain_events)
 {
     if (!info) return;
     memset(info, 0, sizeof(*info));
-    info->initialized = g_lora.initialized ? 1 : 0;
-    info->hw_ready = g_lora.hw_ready ? 1 : 0;
-    info->tx_mode = g_lora.tx_mode ? 1 : 0;
-    info->tx_in_progress = g_lora.tx_in_progress ? 1 : 0;
+    info->initialized      = g_lora.initialized ? 1 : 0;
+    info->hw_ready         = g_lora.hw_ready ? 1 : 0;
+    info->tx_mode          = g_lora.tx_mode ? 1 : 0;
+    info->tx_in_progress   = g_lora.tx_in_progress ? 1 : 0;
     info->has_sent_message = g_lora.has_sent_message ? 1 : 0;
-    info->rx_event = g_lora.rx_event ? 1 : 0;
-    info->tx_event = g_lora.tx_event ? 1 : 0;
+    info->rx_event         = g_lora.rx_event ? 1 : 0;
+    info->tx_event         = g_lora.tx_event ? 1 : 0;
     cp0_copy_cstr(info->spi_device, sizeof(info->spi_device), g_lora.spi.path());
     cp0_copy_cstr(info->last_rx, sizeof(info->last_rx), g_lora.last_rx);
     cp0_copy_cstr(info->last_tx, sizeof(info->last_tx), g_lora.last_tx);
@@ -761,7 +878,7 @@ void get_info(cp0_lora_info_t *info, bool drain_events)
     cp0_copy_cstr(info->probe_display, sizeof(info->probe_display), g_lora.probe_display);
     cp0_copy_cstr(info->pi4io_status, sizeof(info->pi4io_status), cp0_lora_pi4io_controller::status());
     info->rssi = g_lora.last_rssi;
-    info->snr = g_lora.last_snr;
+    info->snr  = g_lora.last_snr;
     if (drain_events) {
         g_lora.rx_event = false;
         g_lora.tx_event = false;
@@ -796,12 +913,7 @@ void set_tx_mode(bool enabled)
 
 void shutdown()
 {
-    g_lora.reset_radio();
-    g_lora.spi.close();
-    g_lora.close_gpio_lines();
-    cp0_lora_hat_power_controller::shutdown();
-    g_lora.initialized = false;
-    g_lora.hw_ready = false;
+    lora_release_hardware();
 }
 
-} // namespace cp0_lora_backend
+}  // namespace cp0_lora_backend

--- a/ext_components/cp0_lvgl/tests/test_lora_runtime_policy.cpp
+++ b/ext_components/cp0_lvgl/tests/test_lora_runtime_policy.cpp
@@ -6,12 +6,20 @@ int main()
 {
     using namespace cp0_lora_runtime_policy;
 
+    assert(tx_timeout_for_airtime_us(0) == TX_TIMEOUT_MS);
+    assert(tx_timeout_for_airtime_us(1000000) == TX_TIMEOUT_MS);
+    assert(tx_timeout_for_airtime_us(5000000) == 9000);
+    assert(tx_timeout_for_airtime_us(5300000) == 9450);
+
     assert(!should_timeout_transmit(false, true, true, 100, 4100));
     assert(!should_timeout_transmit(true, false, true, 100, 4100));
     assert(!should_timeout_transmit(true, true, false, 100, 4100));
     assert(!should_timeout_transmit(true, true, true, 0, 5000));
     assert(!should_timeout_transmit(true, true, true, 100, 4099));
     assert(should_timeout_transmit(true, true, true, 100, 4100));
+    assert(!should_timeout_transmit(true, true, true, 100, 8099, 8000));
+    assert(should_timeout_transmit(true, true, true, 100, 8100, 8000));
+    assert(should_timeout_transmit(true, true, true, 100, 4100, 0));
     assert(!should_timeout_transmit(true, true, true, 4100, 100));
 
     assert(!should_send_demo(false, true, false, 100, 2100));

--- a/projects/APPLaunch/main/ui/page_app/ui_app_lora.cpp
+++ b/projects/APPLaunch/main/ui/page_app/ui_app_lora.cpp
@@ -7,9 +7,22 @@
 #define APP_PAGE_IMPLEMENTATION_UNIT
 #include "ui_app_lora.hpp"
 
+#include <exception>
+#include <mutex>
+#include <thread>
+
 namespace lora_app_detail {
 
-constexpr uint32_t kPollIntervalMs = 300;
+struct LoraInitializationState {
+    std::mutex mutex;
+    bool done        = false;
+    int init_code    = -1;
+    int info_code    = -1;
+    int receive_code = -1;
+    cp0_lora_info_t info{};
+};
+
+constexpr uint32_t kPollIntervalMs   = 300;
 constexpr int32_t kMessageScrollStep = 36;
 
 static bool is_printable_ascii(uint32_t key)
@@ -20,6 +33,69 @@ static bool is_printable_ascii(uint32_t key)
 static char key_to_ascii(uint32_t key)
 {
     return is_printable_ascii(key) ? static_cast<char>(key) : '\0';
+}
+
+static bool is_modifier_event(const key_item *key_event)
+{
+    if (!key_event) return true;
+
+    switch (key_event->key_code) {
+        case KEY_LEFTSHIFT:
+        case KEY_RIGHTSHIFT:
+        case KEY_LEFTCTRL:
+        case KEY_LEFTALT:
+            return true;
+#ifdef KEY_RIGHTCTRL
+        case KEY_RIGHTCTRL:
+            return true;
+#endif
+#ifdef KEY_RIGHTALT
+        case KEY_RIGHTALT:
+            return true;
+#endif
+#ifdef KEY_LEFTMETA
+        case KEY_LEFTMETA:
+            return true;
+#endif
+#ifdef KEY_RIGHTMETA
+        case KEY_RIGHTMETA:
+            return true;
+#endif
+#ifdef KEY_FN
+        case KEY_FN:
+            return true;
+#endif
+#ifdef KEY_COMPOSE
+        case KEY_COMPOSE:
+            return true;
+#endif
+        default:
+            break;
+    }
+
+    // Some firmware revisions expose modifiers through a custom evdev code but
+    // retain the standard XKB name. Do not let those events enter the chat.
+    static constexpr const char *kModifierNames[] = {
+        "Shift_L",     "Shift_R",          "Control_L", "Control_R", "Alt_L",     "Alt_R",
+        "Meta_L",      "Meta_R",           "Super_L",   "Super_R",   "Multi_key", "Menu",
+        "Mode_switch", "ISO_Level3_Shift", "Fn",        "FN",        "Sym",       "SYM",
+    };
+    for (const char *name : kModifierNames) {
+        if (std::strcmp(key_event->sym_name, name) == 0) return true;
+    }
+    return false;
+}
+
+static uint32_t printable_text_key(const key_item *key_event)
+{
+    if (!key_event) return 0;
+
+    // utf8 is the final text produced by xkb/custom TCA mappings. Prefer it
+    // over codepoint: a malformed modifier mapping can leave codepoint set to
+    // a printable symbol even though the event is actually a control key.
+    const unsigned char first = static_cast<unsigned char>(key_event->utf8[0]);
+    if (is_printable_ascii(first) && key_event->utf8[1] == '\0') return first;
+    return is_printable_ascii(key_event->codepoint) ? key_event->codepoint : 0;
 }
 
 static int call_lora_api(const std::list<std::string> &args, cp0_lora_info_t *info = nullptr)
@@ -49,10 +125,44 @@ static bool is_menu_next_key(uint32_t key)
     return key == LV_KEY_RIGHT || key == LV_KEY_NEXT || key == 'c' || key == 'C';
 }
 
-} // namespace lora_app_detail
+}  // namespace lora_app_detail
 
-UILoraPage::UILoraPage()
-    : AppPage()
+namespace {
+
+void run_lora_initialization(const std::shared_ptr<lora_app_detail::LoraInitializationState> &state) noexcept
+{
+    int init_code    = -1;
+    int info_code    = -1;
+    int receive_code = -1;
+    cp0_lora_info_t info{};
+
+    try {
+        init_code = lora_app_detail::call_lora_api({"Init"});
+        info_code = lora_app_detail::call_lora_api({"Info"}, &info);
+        if (init_code == 0 && info_code == 0 && info.hw_ready)
+            receive_code = lora_app_detail::call_lora_api({"StartReceive"});
+    } catch (...) {
+        init_code = -1;
+    }
+
+    if (init_code != 0 && info.diag[0] == '\0')
+        std::snprintf(info.diag, sizeof(info.diag), "LoRa initialization failed (rc=%d)", init_code);
+    else if (info_code != 0 && info.diag[0] == '\0')
+        std::snprintf(info.diag, sizeof(info.diag), "LoRa initialization response unavailable (rc=%d)", info_code);
+    if (receive_code != 0 && info.hw_ready)
+        std::snprintf(info.diag, sizeof(info.diag), "LoRa receive mode unavailable (rc=%d)", receive_code);
+
+    std::lock_guard<std::mutex> lock(state->mutex);
+    state->init_code    = init_code;
+    state->info_code    = info_code;
+    state->receive_code = receive_code;
+    state->info         = info;
+    state->done         = true;
+}
+
+}  // namespace
+
+UILoraPage::UILoraPage() : AppPage()
 {
     set_page_title("LoRa");
     create_ui();
@@ -66,9 +176,7 @@ UILoraPage::UILoraPage()
 
 UILoraPage::~UILoraPage()
 {
-    if (root_screen_)
-        lv_obj_remove_event_cb_with_user_data(
-            root_screen_, UILoraPage::static_key_event_cb, this);
+    if (root_screen_) lv_obj_remove_event_cb_with_user_data(root_screen_, UILoraPage::static_key_event_cb, this);
     cancel_view_animations();
     cancel_message_title_animation();
     app_active_ = false;
@@ -76,32 +184,74 @@ UILoraPage::~UILoraPage()
     detach_delete_callbacks();
 }
 
-
 void UILoraPage::init_lora()
 {
-    if (!ui_ready())
-        return;
-    app_active_ = true;
+    if (!ui_ready()) return;
+    app_active_               = true;
+    initialization_pending_   = true;
     scroll_to_latest_pending_ = false;
     lv_obj_clean(message_list_);
     last_message_row_ = nullptr;
     set_visible(empty_message_label_, true);
     set_visible(empty_message_hint_label_, true);
-
-    (void)lora_app_detail::call_lora_api({"Init"});
-    refresh_lora_info(true);
-    lora_info_.rx_event = 0;
-    lora_info_.tx_event = 0;
-    model_.reset(lora_info_.hw_ready);
+    lv_label_set_text(empty_message_hint_label_, "Initializing LoRa...");
+    lv_obj_set_style_text_color(empty_message_hint_label_, lv_color_hex(0xC9A45C), LV_PART_MAIN | LV_STATE_DEFAULT);
+    std::snprintf(lora_info_.diag, sizeof(lora_info_.diag), "Initializing LoRa hardware...");
+    lora_info_.rx_event    = 0;
+    lora_info_.tx_event    = 0;
+    lora_info_.hw_ready    = 0;
+    lora_info_.initialized = 0;
+    model_.reset(false);
     render_current_view();
-    schedule_message_title_dismissal();
-    if (lora_info_.hw_ready) (void)lora_app_detail::call_lora_api({"StartReceive"});
     poll_timer_.start(
-        [this] {
-            return lv_timer_create(&UILoraPage::static_poll_timer_cb,
-                                   lora_app_detail::kPollIntervalMs, this);
-        },
+        [this] { return lv_timer_create(&UILoraPage::static_poll_timer_cb, lora_app_detail::kPollIntervalMs, this); },
         [](lv_timer_t *timer) { lv_timer_delete(timer); });
+
+    start_lora_initialization();
+}
+
+void UILoraPage::start_lora_initialization()
+{
+    initialization_state_ = std::make_shared<lora_app_detail::LoraInitializationState>();
+    const auto state      = initialization_state_;
+    try {
+        std::thread([state] { run_lora_initialization(state); }).detach();
+    } catch (...) {
+        std::lock_guard<std::mutex> lock(state->mutex);
+        state->init_code    = -1;
+        state->info_code    = -1;
+        state->receive_code = -1;
+        std::snprintf(state->info.diag, sizeof(state->info.diag), "Unable to start LoRa initialization");
+        state->done = true;
+    }
+}
+
+bool UILoraPage::consume_lora_initialization()
+{
+    if (!initialization_pending_ || !initialization_state_) return false;
+
+    cp0_lora_info_t info{};
+    {
+        std::lock_guard<std::mutex> lock(initialization_state_->mutex);
+        if (!initialization_state_->done) return false;
+        info = initialization_state_->info;
+    }
+
+    initialization_pending_ = false;
+    lora_info_              = info;
+    lora_info_.rx_event     = 0;
+    lora_info_.tx_event     = 0;
+    model_.reset(lora_info_.hw_ready != 0);
+    if (lora_info_.hw_ready) {
+        lv_label_set_text(empty_message_hint_label_, "Type anything to send");
+        lv_obj_set_style_text_color(empty_message_hint_label_, lv_color_hex(0x5FE492), LV_PART_MAIN | LV_STATE_DEFAULT);
+    } else {
+        lv_label_set_text(empty_message_hint_label_, "LoRa unavailable; see Info");
+        lv_obj_set_style_text_color(empty_message_hint_label_, lv_color_hex(0xD96C6C), LV_PART_MAIN | LV_STATE_DEFAULT);
+    }
+    render_current_view();
+    if (lora_info_.hw_ready) schedule_message_title_dismissal();
+    return true;
 }
 
 bool UILoraPage::refresh_lora_info(bool poll)
@@ -112,6 +262,10 @@ bool UILoraPage::refresh_lora_info(bool poll)
 void UILoraPage::append_chat_message(const char *text, bool outgoing, float rssi, float snr)
 {
     if (!message_list_) return;
+    // A new bubble should never sit underneath the temporary Messages HUD.
+    // The title is only an entry hint, so dismiss it as soon as real content
+    // arrives instead of waiting for its timer.
+    dismiss_message_title();
     const bool history_full = model_.messages().size() >= LoraPageModel::MESSAGE_HISTORY_LIMIT;
     if (history_full) {
         lv_obj_t *oldest_row = lv_obj_get_child(message_list_, 0);
@@ -121,8 +275,10 @@ void UILoraPage::append_chat_message(const char *text, bool outgoing, float rssi
     last_message_row_ = append_message_row(model_.messages().back());
     set_visible(empty_message_label_, false);
     set_visible(empty_message_hint_label_, false);
-    if (model_.view() == LoraView::MESSAGES) scroll_to_latest(LV_ANIM_ON);
-    else scroll_to_latest_pending_ = true;
+    if (model_.view() == LoraView::MESSAGES)
+        scroll_to_latest(LV_ANIM_ON);
+    else
+        scroll_to_latest_pending_ = true;
 }
 
 void UILoraPage::open_send_view(uint32_t first_key)
@@ -172,8 +328,7 @@ bool UILoraPage::handle_navigation_key(uint32_t key)
         return true;
     }
     if (model_.view() == LoraView::MESSAGES && (key == LV_KEY_UP || key == LV_KEY_DOWN)) {
-        scroll_messages(key == LV_KEY_UP ? lora_app_detail::kMessageScrollStep
-                                         : -lora_app_detail::kMessageScrollStep);
+        scroll_messages(key == LV_KEY_UP ? lora_app_detail::kMessageScrollStep : -lora_app_detail::kMessageScrollStep);
         return true;
     }
     if (model_.view() != LoraView::MESSAGES && (key == LV_KEY_UP || key == LV_KEY_DOWN)) {
@@ -182,11 +337,12 @@ bool UILoraPage::handle_navigation_key(uint32_t key)
         return true;
     }
     if (key == LV_KEY_ENTER) {
+        if (initialization_pending_ || !lora_info_.hw_ready) return true;
         open_send_view(0);
         return true;
     }
-    if (lora_app_detail::is_printable_ascii(key) && key != 'z' && key != 'Z' &&
-        key != 'c' && key != 'C') {
+    if (initialization_pending_ || !lora_info_.hw_ready) return lora_app_detail::is_printable_ascii(key);
+    if (lora_app_detail::is_printable_ascii(key) && key != 'z' && key != 'Z' && key != 'c' && key != 'C') {
         open_send_view(key);
         return true;
     }
@@ -210,6 +366,11 @@ void UILoraPage::append_text_key(uint32_t key)
 
 void UILoraPage::send_current_text()
 {
+    if (initialization_pending_ || !lora_info_.hw_ready) {
+        model_.set_send_status("LoRa is still initializing");
+        update_send_content();
+        return;
+    }
     if (model_.tx_input().empty()) {
         model_.set_send_status("Message is empty :(");
         update_send_content();
@@ -229,12 +390,13 @@ void UILoraPage::send_current_text()
 
 uint32_t UILoraPage::normalize_key(const key_item *key_event) const
 {
-    uint32_t key = key_event->key_code;
-    if (model_.view() != LoraView::SEND) {
-        if (key == KEY_F) return LV_KEY_UP;
-        if (key == KEY_X) return LV_KEY_DOWN;
-    }
-    if (lora_app_detail::is_printable_ascii(key_event->codepoint)) return key_event->codepoint;
+    if (!key_event || lora_app_detail::is_modifier_event(key_event)) return 0;
+
+    const uint32_t key = key_event->key_code;
+
+    // Handle physical navigation keys before consulting text metadata. This
+    // keeps a stale/incorrect codepoint on Enter or an arrow from becoming a
+    // chat character.
     if (key == KEY_UP) return LV_KEY_UP;
     if (key == KEY_DOWN) return LV_KEY_DOWN;
     if (key == KEY_LEFT) return LV_KEY_LEFT;
@@ -243,22 +405,33 @@ uint32_t UILoraPage::normalize_key(const key_item *key_event) const
     if (key == KEY_ESC) return LV_KEY_ESC;
     if (key == KEY_BACKSPACE) return LV_KEY_BACKSPACE;
     if (key == KEY_DELETE) return LV_KEY_DEL;
-    return key;
+
+    if (model_.view() != LoraView::SEND) {
+        if (key == KEY_F) return LV_KEY_UP;
+        if (key == KEY_X) return LV_KEY_DOWN;
+    }
+
+    return lora_app_detail::printable_text_key(key_event);
 }
 
 void UILoraPage::on_key_event(lv_event_t *event)
 {
     auto *key_event = static_cast<key_item *>(lv_event_get_param(event));
     if (!key_event || key_event->key_state == KBD_KEY_RELEASED) return;
-    (void)handle_key(normalize_key(key_event));
+    const uint32_t key = normalize_key(key_event);
+    if (key != 0) (void)handle_key(key);
 }
 
 void UILoraPage::on_poll_timer()
 {
     if (!app_active_ || !page_root_) return;
+    if (initialization_pending_) {
+        (void)consume_lora_initialization();
+        return;
+    }
+    if (!lora_info_.hw_ready) return;
     if (!refresh_lora_info(true)) return;
-    if (lora_info_.rx_event)
-        append_chat_message(lora_info_.last_rx, false, lora_info_.rssi, lora_info_.snr);
+    if (lora_info_.rx_event) append_chat_message(lora_info_.last_rx, false, lora_info_.rssi, lora_info_.snr);
     if (model_.view() == LoraView::INFO) update_info_content();
 }
 
@@ -268,9 +441,9 @@ void UILoraPage::static_cancel_button_cb(lv_event_t *event) noexcept
     try {
         if (!event) return;
         self = static_cast<UILoraPage *>(lv_event_get_user_data(event));
-        if (!self || !lora_send_action_callback_allowed(
-                lv_event_get_current_target(event), self->send_cancel_button_,
-                self->app_active_, self->model_.view() == LoraView::SEND)) return;
+        if (!self || !lora_send_action_callback_allowed(lv_event_get_current_target(event), self->send_cancel_button_,
+                                                        self->app_active_, self->model_.view() == LoraView::SEND))
+            return;
         self->cancel_send();
     } catch (...) {
         if (self) self->app_active_ = false;
@@ -283,9 +456,9 @@ void UILoraPage::static_send_button_cb(lv_event_t *event) noexcept
     try {
         if (!event) return;
         self = static_cast<UILoraPage *>(lv_event_get_user_data(event));
-        if (!self || !lora_send_action_callback_allowed(
-                lv_event_get_current_target(event), self->send_confirm_button_,
-                self->app_active_, self->model_.view() == LoraView::SEND)) return;
+        if (!self || !lora_send_action_callback_allowed(lv_event_get_current_target(event), self->send_confirm_button_,
+                                                        self->app_active_, self->model_.view() == LoraView::SEND))
+            return;
         self->send_current_text();
     } catch (...) {
         if (self) self->app_active_ = false;
@@ -308,10 +481,10 @@ void UILoraPage::static_key_event_cb(lv_event_t *event) noexcept
             }
             return;
         }
-        if (lv_event_get_code(event) != static_cast<lv_event_code_t>(LV_EVENT_KEYBOARD) ||
-            !self || !lora_page_event_callback_allowed(
-                lv_event_get_current_target(event), self->root_screen_,
-                self->app_active_)) return;
+        if (lv_event_get_code(event) != static_cast<lv_event_code_t>(LV_EVENT_KEYBOARD) || !self ||
+            !lora_page_event_callback_allowed(lv_event_get_current_target(event), self->root_screen_,
+                                              self->app_active_))
+            return;
         self->on_key_event(event);
     } catch (...) {
         if (self) self->app_active_ = false;
@@ -323,9 +496,7 @@ void UILoraPage::static_poll_timer_cb(lv_timer_t *timer) noexcept
     auto *self = static_cast<UILoraPage *>(lv_timer_get_user_data(timer));
     if (!self) return;
     try {
-        if (lora_poll_callback_allowed(
-                self->poll_timer_.current(timer), self->app_active_))
-            self->on_poll_timer();
+        if (lora_poll_callback_allowed(self->poll_timer_.current(timer), self->app_active_)) self->on_poll_timer();
     } catch (...) {
         self->app_active_ = false;
     }

--- a/projects/APPLaunch/main/ui/page_app/ui_app_lora.cpp
+++ b/projects/APPLaunch/main/ui/page_app/ui_app_lora.cpp
@@ -70,6 +70,7 @@ UILoraPage::~UILoraPage()
         lv_obj_remove_event_cb_with_user_data(
             root_screen_, UILoraPage::static_key_event_cb, this);
     cancel_view_animations();
+    cancel_message_title_animation();
     app_active_ = false;
     poll_timer_.stop();
     detach_delete_callbacks();
@@ -93,6 +94,7 @@ void UILoraPage::init_lora()
     lora_info_.tx_event = 0;
     model_.reset(lora_info_.hw_ready);
     render_current_view();
+    schedule_message_title_dismissal();
     if (lora_info_.hw_ready) (void)lora_app_detail::call_lora_api({"StartReceive"});
     poll_timer_.start(
         [this] {
@@ -131,6 +133,7 @@ void UILoraPage::open_send_view(uint32_t first_key)
 
 void UILoraPage::scroll_messages(int32_t amount)
 {
+    dismiss_message_title();
     if (message_list_) lv_obj_scroll_by_bounded(message_list_, 0, amount, LV_ANIM_ON);
 }
 
@@ -300,6 +303,7 @@ void UILoraPage::static_key_event_cb(lv_event_t *event) noexcept
             if (self && lv_event_get_current_target(event) == self->root_screen_) {
                 self->app_active_ = false;
                 self->poll_timer_.stop();
+                self->cancel_message_title_animation();
                 self->cancel_view_animations();
             }
             return;
@@ -322,6 +326,18 @@ void UILoraPage::static_poll_timer_cb(lv_timer_t *timer) noexcept
         if (lora_poll_callback_allowed(
                 self->poll_timer_.current(timer), self->app_active_))
             self->on_poll_timer();
+    } catch (...) {
+        self->app_active_ = false;
+    }
+}
+
+void UILoraPage::static_message_title_timer_cb(lv_timer_t *timer) noexcept
+{
+    auto *self = timer ? static_cast<UILoraPage *>(lv_timer_get_user_data(timer)) : nullptr;
+    if (!self || self->message_title_timer_ != timer) return;
+    self->message_title_timer_ = nullptr;
+    try {
+        self->dismiss_message_title();
     } catch (...) {
         self->app_active_ = false;
     }

--- a/projects/APPLaunch/main/ui/page_app/ui_app_lora.hpp
+++ b/projects/APPLaunch/main/ui/page_app/ui_app_lora.hpp
@@ -39,9 +39,11 @@ private:
     cp0_lora_info_t lora_info_{};
 
     PageTimerLifecycle<lv_timer_t *> poll_timer_;
+    lv_timer_t *message_title_timer_ = nullptr;
     lv_obj_t *page_root_                = nullptr;
     lv_obj_t *messages_view_            = nullptr;
     lv_obj_t *message_list_             = nullptr;
+    lv_obj_t *messages_title_           = nullptr;
     lv_obj_t *empty_message_label_      = nullptr;
     lv_obj_t *empty_message_hint_label_ = nullptr;
     lv_obj_t *last_message_row_         = nullptr;
@@ -101,6 +103,11 @@ private:
     void update_info_content();
     void update_send_content();
     void scroll_to_latest(lv_anim_enable_t animation);
+    void schedule_message_title_dismissal();
+    void dismiss_message_title();
+    void cancel_message_title_animation();
+    static void message_title_anim_exec_cb(void *object, int32_t y) noexcept;
+    static void hide_message_title_after_anim_cb(lv_anim_t *animation) noexcept;
     static void view_opa_exec_cb(void *object, int32_t opacity) noexcept;
     static void hide_view_after_fade_cb(lv_anim_t *animation) noexcept;
     static void cancel_view_animation(lv_obj_t *view);
@@ -128,4 +135,5 @@ private:
     static void static_send_button_cb(lv_event_t *event) noexcept;
     static void static_key_event_cb(lv_event_t *event) noexcept;
     static void static_poll_timer_cb(lv_timer_t *timer) noexcept;
+    static void static_message_title_timer_cb(lv_timer_t *timer) noexcept;
 };

--- a/projects/APPLaunch/main/ui/page_app/ui_app_lora.hpp
+++ b/projects/APPLaunch/main/ui/page_app/ui_app_lora.hpp
@@ -24,8 +24,13 @@
 #include <deque>
 #include <functional>
 #include <list>
+#include <memory>
 #include <string>
 #include <utility>
+
+namespace lora_app_detail {
+struct LoraInitializationState;
+}
 
 class UILoraPage : public AppPage {
 public:
@@ -35,11 +40,13 @@ public:
 private:
     LoraPageModel model_;
     bool app_active_               = false;
+    bool initialization_pending_   = false;
     bool scroll_to_latest_pending_ = false;
     cp0_lora_info_t lora_info_{};
+    std::shared_ptr<lora_app_detail::LoraInitializationState> initialization_state_;
 
     PageTimerLifecycle<lv_timer_t *> poll_timer_;
-    lv_timer_t *message_title_timer_ = nullptr;
+    lv_timer_t *message_title_timer_    = nullptr;
     lv_obj_t *page_root_                = nullptr;
     lv_obj_t *messages_view_            = nullptr;
     lv_obj_t *message_list_             = nullptr;
@@ -74,8 +81,7 @@ private:
                                           lv_coord_t height);
 
     static lv_obj_t *make_label(lv_obj_t *parent, const char *text, lv_coord_t x, lv_coord_t y, lv_coord_t width,
-                                lv_coord_t height, const lv_font_t *font, lv_color_t color,
-                                lv_text_align_t align);
+                                lv_coord_t height, const lv_font_t *font, lv_color_t color, lv_text_align_t align);
 
     static lv_obj_t *make_divider(lv_obj_t *parent, lv_coord_t y);
 
@@ -87,8 +93,7 @@ private:
     void create_send_view();
 
     lv_obj_t *make_action_button(lv_obj_t *parent, lv_coord_t x, lv_coord_t y, lv_coord_t width, const char *text,
-                                 lv_color_t background, lv_color_t foreground,
-                                 lv_event_cb_t callback);
+                                 lv_color_t background, lv_color_t foreground, lv_event_cb_t callback);
     void create_page_indicator();
     void bind_events();
     void track_owned_handle(lv_obj_t *object);
@@ -98,6 +103,8 @@ private:
     static void static_owned_obj_delete_cb(lv_event_t *event) noexcept;
 
     void init_lora();
+    void start_lora_initialization();
+    bool consume_lora_initialization();
     bool refresh_lora_info(bool poll);
     void update_page_indicator();
     void update_info_content();
@@ -112,8 +119,7 @@ private:
     static void hide_view_after_fade_cb(lv_anim_t *animation) noexcept;
     static void cancel_view_animation(lv_obj_t *view);
     void cancel_view_animations();
-    static void animate_view_opacity(lv_obj_t *view, lv_opa_t start, lv_opa_t end,
-                                     bool hide_after_fade);
+    static void animate_view_opacity(lv_obj_t *view, lv_opa_t start, lv_opa_t end, bool hide_after_fade);
     void transition_to_view(lv_obj_t *target);
     void render_current_view();
 

--- a/projects/APPLaunch/main/ui/page_app/ui_app_lora_view.cpp
+++ b/projects/APPLaunch/main/ui/page_app/ui_app_lora_view.cpp
@@ -9,33 +9,34 @@
 
 namespace lora_app_detail {
 
-constexpr lv_coord_t kScreenWidth = 320;
-constexpr lv_coord_t kContentHeight = 150;
-constexpr uint32_t kViewTransitionMs = 150;
-constexpr uint32_t kMessageTitleHoldMs = 3200;
-constexpr uint32_t kMessageTitleHideMs = 340;
-constexpr lv_coord_t kMessageTitleShownY = -8;
+constexpr lv_coord_t kScreenWidth         = 320;
+constexpr lv_coord_t kContentHeight       = 150;
+constexpr uint32_t kViewTransitionMs      = 150;
+constexpr uint32_t kMessageTitleHoldMs    = 3200;
+constexpr uint32_t kMessageTitleHideMs    = 340;
+constexpr lv_coord_t kMessageTitleShownY  = -8;
 constexpr lv_coord_t kMessageTitleHiddenY = -29;
-constexpr lv_coord_t kBubbleTailWidth = 6;
-constexpr lv_coord_t kBubbleTailDrop = 3;
+constexpr lv_coord_t kBubbleTailWidth     = 6;
+constexpr lv_coord_t kBubbleTailDrop      = 3;
 
 static const char *safe_text(const char *text, const char *fallback = "")
 {
     return text && text[0] ? text : fallback;
 }
 
-} // namespace lora_app_detail
+}  // namespace lora_app_detail
 
 void UILoraPage::set_visible(lv_obj_t *object, bool visible)
 {
     if (!object) return;
-    if (visible) lv_obj_clear_flag(object, LV_OBJ_FLAG_HIDDEN);
-    else lv_obj_add_flag(object, LV_OBJ_FLAG_HIDDEN);
+    if (visible)
+        lv_obj_clear_flag(object, LV_OBJ_FLAG_HIDDEN);
+    else
+        lv_obj_add_flag(object, LV_OBJ_FLAG_HIDDEN);
 }
 
-lv_obj_t *UILoraPage::make_panel(lv_obj_t *parent, lv_coord_t x, lv_coord_t y,
-                                 lv_coord_t width, lv_coord_t height, lv_color_t color,
-                                 lv_opa_t opacity, lv_coord_t radius)
+lv_obj_t *UILoraPage::make_panel(lv_obj_t *parent, lv_coord_t x, lv_coord_t y, lv_coord_t width, lv_coord_t height,
+                                 lv_color_t color, lv_opa_t opacity, lv_coord_t radius)
 {
     if (!parent) return nullptr;
     lv_obj_t *panel = lv_obj_create(parent);
@@ -52,16 +53,14 @@ lv_obj_t *UILoraPage::make_panel(lv_obj_t *parent, lv_coord_t x, lv_coord_t y,
     return panel;
 }
 
-lv_obj_t *UILoraPage::make_plain_container(lv_obj_t *parent, lv_coord_t x, lv_coord_t y,
-                                           lv_coord_t width, lv_coord_t height)
+lv_obj_t *UILoraPage::make_plain_container(lv_obj_t *parent, lv_coord_t x, lv_coord_t y, lv_coord_t width,
+                                           lv_coord_t height)
 {
     return make_panel(parent, x, y, width, height, lv_color_hex(0x000000), LV_OPA_TRANSP, 0);
 }
 
-lv_obj_t *UILoraPage::make_label(lv_obj_t *parent, const char *text, lv_coord_t x,
-                                 lv_coord_t y, lv_coord_t width, lv_coord_t height,
-                                 const lv_font_t *font, lv_color_t color,
-                                 lv_text_align_t align)
+lv_obj_t *UILoraPage::make_label(lv_obj_t *parent, const char *text, lv_coord_t x, lv_coord_t y, lv_coord_t width,
+                                 lv_coord_t height, const lv_font_t *font, lv_color_t color, lv_text_align_t align)
 {
     if (!parent) return nullptr;
     lv_obj_t *label = lv_label_create(parent);
@@ -70,8 +69,7 @@ lv_obj_t *UILoraPage::make_label(lv_obj_t *parent, const char *text, lv_coord_t 
     lv_label_set_text(label, text ? text : "");
     lv_obj_set_pos(label, x, y);
     lv_obj_set_size(label, width, height);
-    lv_obj_set_style_text_font(label, font ? font : &lv_font_montserrat_12,
-                               LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_text_font(label, font ? font : &lv_font_montserrat_12, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_text_color(label, color, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_text_opa(label, LV_OPA_COVER, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_text_align(label, align, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -88,7 +86,7 @@ lv_obj_t *UILoraPage::make_divider(lv_obj_t *parent, lv_coord_t y)
 void UILoraPage::bubble_tail_draw_cb(lv_event_t *event) noexcept
 {
     if (!event) return;
-    lv_obj_t *row = lv_event_get_target_obj(event);
+    lv_obj_t *row     = lv_event_get_target_obj(event);
     lv_layer_t *layer = lv_event_get_layer(event);
     if (!row || !layer) return;
     lv_obj_t *bubble = lv_obj_get_child(row, 0);
@@ -98,23 +96,20 @@ void UILoraPage::bubble_tail_draw_cb(lv_event_t *event) noexcept
     lv_obj_get_coords(bubble, &area);
     lv_draw_triangle_dsc_t draw_dsc;
     lv_draw_triangle_dsc_init(&draw_dsc);
-    draw_dsc.color = lv_obj_get_style_bg_color(bubble, LV_PART_MAIN);
-    draw_dsc.opa = lv_obj_get_style_bg_opa(bubble, LV_PART_MAIN);
+    draw_dsc.color             = lv_obj_get_style_bg_color(bubble, LV_PART_MAIN);
+    draw_dsc.opa               = lv_obj_get_style_bg_opa(bubble, LV_PART_MAIN);
     lv_opa_t recursive_opacity = lv_obj_get_style_opa_recursive(bubble, LV_PART_MAIN);
-    if (recursive_opacity < LV_OPA_MAX)
-        draw_dsc.opa = LV_OPA_MIX2(draw_dsc.opa, recursive_opacity);
+    if (recursive_opacity < LV_OPA_MAX) draw_dsc.opa = LV_OPA_MIX2(draw_dsc.opa, recursive_opacity);
 
-    static constexpr lv_coord_t TAIL_RISE = 9;
+    static constexpr lv_coord_t TAIL_RISE     = 9;
     static constexpr lv_coord_t TAIL_SHOULDER = 10;
-    bool outgoing = lv_obj_has_flag(row, LV_OBJ_FLAG_USER_1);
-    lv_coord_t side_x = outgoing ? area.x2 : area.x1;
-    lv_coord_t shoulder_x = outgoing ? area.x2 - TAIL_SHOULDER : area.x1 + TAIL_SHOULDER;
-    lv_coord_t tip_x = outgoing ? area.x2 + lora_app_detail::kBubbleTailWidth
-                                : area.x1 - lora_app_detail::kBubbleTailWidth;
-    draw_dsc.p[0] = {static_cast<lv_value_precise_t>(side_x),
-                     static_cast<lv_value_precise_t>(area.y2 - TAIL_RISE)};
-    draw_dsc.p[1] = {static_cast<lv_value_precise_t>(shoulder_x),
-                     static_cast<lv_value_precise_t>(area.y2)};
+    bool outgoing                             = lv_obj_has_flag(row, LV_OBJ_FLAG_USER_1);
+    lv_coord_t side_x                         = outgoing ? area.x2 : area.x1;
+    lv_coord_t shoulder_x                     = outgoing ? area.x2 - TAIL_SHOULDER : area.x1 + TAIL_SHOULDER;
+    lv_coord_t tip_x =
+        outgoing ? area.x2 + lora_app_detail::kBubbleTailWidth : area.x1 - lora_app_detail::kBubbleTailWidth;
+    draw_dsc.p[0] = {static_cast<lv_value_precise_t>(side_x), static_cast<lv_value_precise_t>(area.y2 - TAIL_RISE)};
+    draw_dsc.p[1] = {static_cast<lv_value_precise_t>(shoulder_x), static_cast<lv_value_precise_t>(area.y2)};
     draw_dsc.p[2] = {static_cast<lv_value_precise_t>(tip_x),
                      static_cast<lv_value_precise_t>(area.y2 + lora_app_detail::kBubbleTailDrop)};
     lv_draw_triangle(layer, &draw_dsc);
@@ -124,33 +119,32 @@ void UILoraPage::update_page_indicator()
 {
     if (!page_dots_[0] || !page_dots_[1]) return;
     bool messages_active = model_.view() == LoraView::MESSAGES;
-    lv_obj_set_style_bg_color(page_dots_[0],
-                              lv_color_hex(messages_active ? 0xE4E4E4 : 0x4E5157),
+    lv_obj_set_style_bg_color(page_dots_[0], lv_color_hex(messages_active ? 0xE4E4E4 : 0x4E5157),
                               LV_PART_MAIN | LV_STATE_DEFAULT);
-    lv_obj_set_style_bg_color(page_dots_[1],
-                              lv_color_hex(messages_active ? 0x4E5157 : 0xE4E4E4),
+    lv_obj_set_style_bg_color(page_dots_[1], lv_color_hex(messages_active ? 0x4E5157 : 0xE4E4E4),
                               LV_PART_MAIN | LV_STATE_DEFAULT);
 }
 
 void UILoraPage::update_info_content()
 {
-    if (!info_status_label_ || !info_status_dot_ || !info_device_value_ ||
-        !info_rssi_value_ || !info_snr_value_ || !info_link_value_ || !info_diag_value_)
+    if (!info_status_label_ || !info_status_dot_ || !info_device_value_ || !info_rssi_value_ || !info_snr_value_ ||
+        !info_link_value_ || !info_diag_value_)
         return;
     const char *state_text = "RECEIVING";
-    uint32_t state_color = 0x69AD80;
-    if (!lora_info_.hw_ready) {
-        state_text = "RADIO OFF";
+    uint32_t state_color   = 0x69AD80;
+    if (initialization_pending_) {
+        state_text  = "INITIALIZING";
+        state_color = 0xC9A45C;
+    } else if (!lora_info_.hw_ready) {
+        state_text  = "RADIO OFF";
         state_color = 0xD96C6C;
     } else if (lora_info_.tx_in_progress || lora_info_.tx_mode) {
-        state_text = lora_info_.tx_in_progress ? "SENDING" : "TX MODE";
+        state_text  = lora_info_.tx_in_progress ? "SENDING" : "TX MODE";
         state_color = 0xC9A45C;
     }
     lv_label_set_text(info_status_label_, state_text);
-    lv_obj_set_style_bg_color(info_status_dot_, lv_color_hex(state_color),
-                              LV_PART_MAIN | LV_STATE_DEFAULT);
-    lv_label_set_text(info_device_value_,
-                      lora_app_detail::safe_text(lora_info_.spi_device, "Unavailable"));
+    lv_obj_set_style_bg_color(info_status_dot_, lv_color_hex(state_color), LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_label_set_text(info_device_value_, lora_app_detail::safe_text(lora_info_.spi_device, "Unavailable"));
 
     char value[64];
     std::snprintf(value, sizeof(value), "%.0f dBm", lora_info_.rssi);
@@ -158,13 +152,10 @@ void UILoraPage::update_info_content()
     std::snprintf(value, sizeof(value), "%.1f dB", lora_info_.snr);
     lv_label_set_text(info_snr_value_, value);
     lv_label_set_text(info_link_value_,
-                      lora_app_detail::safe_text(lora_info_.probe_display,
-                                                 "Link configuration unavailable"));
-    lv_label_set_text(info_diag_value_,
-                      lora_app_detail::safe_text(lora_info_.diag, "No diagnostics"));
-    lv_obj_set_style_text_color(info_diag_value_,
-                                lv_color_hex(lora_info_.hw_ready ? 0x777B82 : 0xD96C6C),
-                                LV_PART_MAIN | LV_STATE_DEFAULT);
+                      lora_app_detail::safe_text(lora_info_.probe_display, "Link configuration unavailable"));
+    lv_label_set_text(info_diag_value_, lora_app_detail::safe_text(lora_info_.diag, "No diagnostics"));
+    const uint32_t diag_color = initialization_pending_ ? 0xC9A45C : (lora_info_.hw_ready ? 0x777B82 : 0xD96C6C);
+    lv_obj_set_style_text_color(info_diag_value_, lv_color_hex(diag_color), LV_PART_MAIN | LV_STATE_DEFAULT);
 }
 
 void UILoraPage::update_send_content()
@@ -172,8 +163,7 @@ void UILoraPage::update_send_content()
     if (!send_input_label_ || !send_status_label_) return;
     std::string display = model_.tx_input() + "|";
     lv_label_set_text(send_input_label_, display.c_str());
-    lv_obj_set_style_text_color(send_input_label_, lv_color_hex(0xFFFFFF),
-                                LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_text_color(send_input_label_, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
     bool has_status = !model_.send_status().empty();
     lv_label_set_text(send_status_label_, has_status ? model_.send_status().c_str() : "");
     set_visible(send_status_label_, has_status);
@@ -192,14 +182,11 @@ void UILoraPage::scroll_to_latest(lv_anim_enable_t animation)
 
 void UILoraPage::schedule_message_title_dismissal()
 {
-    if (!messages_title_ || message_title_timer_ ||
-        lv_obj_has_flag(messages_title_, LV_OBJ_FLAG_HIDDEN))
-        return;
+    if (!messages_title_ || message_title_timer_ || lv_obj_has_flag(messages_title_, LV_OBJ_FLAG_HIDDEN)) return;
 
-    message_title_timer_ = lv_timer_create(
-        &UILoraPage::static_message_title_timer_cb, lora_app_detail::kMessageTitleHoldMs, this);
-    if (message_title_timer_)
-        lv_timer_set_repeat_count(message_title_timer_, 1);
+    message_title_timer_ =
+        lv_timer_create(&UILoraPage::static_message_title_timer_cb, lora_app_detail::kMessageTitleHoldMs, this);
+    if (message_title_timer_) lv_timer_set_repeat_count(message_title_timer_, 1);
 }
 
 void UILoraPage::cancel_message_title_animation()
@@ -208,14 +195,12 @@ void UILoraPage::cancel_message_title_animation()
         lv_timer_delete(message_title_timer_);
         message_title_timer_ = nullptr;
     }
-    if (messages_title_)
-        lv_anim_del(messages_title_, &UILoraPage::message_title_anim_exec_cb);
+    if (messages_title_) lv_anim_del(messages_title_, &UILoraPage::message_title_anim_exec_cb);
 }
 
 void UILoraPage::dismiss_message_title()
 {
-    if (!messages_title_ || lv_obj_has_flag(messages_title_, LV_OBJ_FLAG_HIDDEN))
-        return;
+    if (!messages_title_ || lv_obj_has_flag(messages_title_, LV_OBJ_FLAG_HIDDEN)) return;
 
     if (message_title_timer_) {
         lv_timer_delete(message_title_timer_);
@@ -226,8 +211,7 @@ void UILoraPage::dismiss_message_title()
     lv_anim_t animation;
     lv_anim_init(&animation);
     lv_anim_set_var(&animation, messages_title_);
-    lv_anim_set_values(&animation, lv_obj_get_y(messages_title_),
-                       lora_app_detail::kMessageTitleHiddenY);
+    lv_anim_set_values(&animation, lv_obj_get_y(messages_title_), lora_app_detail::kMessageTitleHiddenY);
     lv_anim_set_time(&animation, lora_app_detail::kMessageTitleHideMs);
     lv_anim_set_path_cb(&animation, lv_anim_path_ease_out);
     lv_anim_set_exec_cb(&animation, &UILoraPage::message_title_anim_exec_cb);
@@ -282,8 +266,7 @@ void UILoraPage::cancel_view_animations()
     cancel_view_animation(send_view_);
 }
 
-void UILoraPage::animate_view_opacity(lv_obj_t *view, lv_opa_t start, lv_opa_t end,
-                                      bool hide_after_fade)
+void UILoraPage::animate_view_opacity(lv_obj_t *view, lv_opa_t start, lv_opa_t end, bool hide_after_fade)
 {
     if (!view) return;
     cancel_view_animation(view);
@@ -323,10 +306,10 @@ void UILoraPage::transition_to_view(lv_obj_t *target)
         return;
     }
 
-    lv_obj_t *outgoing = active_view_;
+    lv_obj_t *outgoing      = active_view_;
     lv_opa_t outgoing_start = lv_obj_get_style_opa(outgoing, LV_PART_MAIN);
-    lv_opa_t incoming_start = lv_obj_has_flag(target, LV_OBJ_FLAG_HIDDEN)
-        ? LV_OPA_TRANSP : lv_obj_get_style_opa(target, LV_PART_MAIN);
+    lv_opa_t incoming_start =
+        lv_obj_has_flag(target, LV_OBJ_FLAG_HIDDEN) ? LV_OPA_TRANSP : lv_obj_get_style_opa(target, LV_PART_MAIN);
     animate_view_opacity(outgoing, outgoing_start, LV_OPA_TRANSP, true);
     animate_view_opacity(target, incoming_start, LV_OPA_COVER, false);
     active_view_ = target;
@@ -335,8 +318,8 @@ void UILoraPage::transition_to_view(lv_obj_t *target)
 void UILoraPage::render_current_view()
 {
     bool show_messages = model_.view() == LoraView::MESSAGES;
-    bool show_info = model_.view() == LoraView::INFO;
-    bool show_send = model_.view() == LoraView::SEND;
+    bool show_info     = model_.view() == LoraView::INFO;
+    bool show_send     = model_.view() == LoraView::SEND;
     if (show_info) update_info_content();
     if (show_send) update_send_content();
     transition_to_view(show_messages ? messages_view_ : (show_info ? info_view_ : send_view_));
@@ -347,9 +330,8 @@ void UILoraPage::render_current_view()
 
 void UILoraPage::create_ui()
 {
-    page_root_ = make_panel(ui_APP_Container, 0, 0, lora_app_detail::kScreenWidth,
-                            lora_app_detail::kContentHeight, lv_color_hex(0x0B0C0E),
-                            LV_OPA_COVER, 0);
+    page_root_ = make_panel(ui_APP_Container, 0, 0, lora_app_detail::kScreenWidth, lora_app_detail::kContentHeight,
+                            lv_color_hex(0x0B0C0E), LV_OPA_COVER, 0);
     if (!page_root_) return;
     lv_obj_add_event_cb(page_root_, static_owned_obj_delete_cb, LV_EVENT_DELETE, this);
     create_messages_view();
@@ -357,11 +339,11 @@ void UILoraPage::create_ui()
     create_send_view();
     create_page_indicator();
     lv_obj_t *persistent_children[] = {
-        empty_message_label_, empty_message_hint_label_, info_status_dot_,
-        info_status_label_, info_device_value_, info_rssi_value_, info_snr_value_,
-        info_link_value_, info_diag_value_, send_input_bubble_, send_input_label_,
-        send_status_label_, send_cancel_button_, send_confirm_button_, page_dots_[0],
-        page_dots_[1], messages_title_};
+        empty_message_label_, empty_message_hint_label_, info_status_dot_,  info_status_label_,
+        info_device_value_,   info_rssi_value_,          info_snr_value_,   info_link_value_,
+        info_diag_value_,     send_input_bubble_,        send_input_label_, send_status_label_,
+        send_cancel_button_,  send_confirm_button_,      page_dots_[0],     page_dots_[1],
+        messages_title_};
     for (lv_obj_t *object : persistent_children) track_owned_handle(object);
 }
 
@@ -374,8 +356,7 @@ void UILoraPage::create_messages_view()
     if (!message_list_) return;
     lv_obj_add_event_cb(message_list_, static_owned_obj_delete_cb, LV_EVENT_DELETE, this);
     lv_obj_set_flex_flow(message_list_, LV_FLEX_FLOW_COLUMN);
-    lv_obj_set_flex_align(message_list_, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START,
-                          LV_FLEX_ALIGN_START);
+    lv_obj_set_flex_align(message_list_, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
     lv_obj_set_style_pad_left(message_list_, 10, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_pad_right(message_list_, 10, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_pad_top(message_list_, 20, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -385,17 +366,15 @@ void UILoraPage::create_messages_view()
     lv_obj_set_scroll_dir(message_list_, LV_DIR_VER);
     lv_obj_set_scrollbar_mode(message_list_, LV_SCROLLBAR_MODE_OFF);
 
-    empty_message_label_ = make_label(messages_view_, "No messages yet", 0, 50, 320, 16,
-                                      &lv_font_montserrat_12, lv_color_hex(0xB2B2B2),
-                                      LV_TEXT_ALIGN_CENTER);
-    empty_message_hint_label_ = make_label(messages_view_, "Type anything to send", 0, 68,
-                                           320, 14, &lv_font_montserrat_12,
-                                           lv_color_hex(0x5FE492), LV_TEXT_ALIGN_CENTER);
-    messages_title_ = make_panel(messages_view_, 108, lora_app_detail::kMessageTitleShownY,
-                                 104, 28, lv_color_hex(0x0B0C0E), LV_OPA_COVER, 8);
+    empty_message_label_      = make_label(messages_view_, "No messages yet", 0, 50, 320, 16, &lv_font_montserrat_12,
+                                           lv_color_hex(0xB2B2B2), LV_TEXT_ALIGN_CENTER);
+    empty_message_hint_label_ = make_label(messages_view_, "Type anything to send", 0, 68, 320, 14,
+                                           &lv_font_montserrat_12, lv_color_hex(0x5FE492), LV_TEXT_ALIGN_CENTER);
+    messages_title_           = make_panel(messages_view_, 108, lora_app_detail::kMessageTitleShownY, 104, 28,
+                                           lv_color_hex(0x0B0C0E), LV_OPA_COVER, 8);
     if (messages_title_)
-        make_label(messages_title_, "Messages", 0, 8, 104, 18, &lv_font_montserrat_14,
-                   lv_color_hex(0xE4E4E4), LV_TEXT_ALIGN_CENTER);
+        make_label(messages_title_, "Messages", 0, 8, 104, 18, &lv_font_montserrat_14, lv_color_hex(0xE4E4E4),
+                   LV_TEXT_ALIGN_CENTER);
 }
 
 void UILoraPage::create_info_view()
@@ -403,35 +382,31 @@ void UILoraPage::create_info_view()
     info_view_ = make_plain_container(page_root_, 0, 0, 320, 150);
     if (!info_view_) return;
     lv_obj_add_event_cb(info_view_, static_owned_obj_delete_cb, LV_EVENT_DELETE, this);
-    make_label(info_view_, "LoRa Info", 0, 0, 320, 18, &lv_font_montserrat_14,
-               lv_color_hex(0xE4E4E4), LV_TEXT_ALIGN_CENTER);
-    info_status_dot_ = make_panel(info_view_, 8, 23, 6, 6, lv_color_hex(0x69AD80),
-                                  LV_OPA_COVER, LV_RADIUS_CIRCLE);
-    info_status_label_ = make_label(info_view_, "", 20, 20, 180, 16, &lv_font_montserrat_10,
-                                    lv_color_hex(0xAEB2B8), LV_TEXT_ALIGN_LEFT);
-    make_label(info_view_, "CLIENT", 240, 20, 72, 16, &lv_font_montserrat_10,
-               lv_color_hex(0x777B82), LV_TEXT_ALIGN_RIGHT);
+    make_label(info_view_, "LoRa Info", 0, 0, 320, 18, &lv_font_montserrat_14, lv_color_hex(0xE4E4E4),
+               LV_TEXT_ALIGN_CENTER);
+    info_status_dot_ = make_panel(info_view_, 8, 23, 6, 6, lv_color_hex(0x69AD80), LV_OPA_COVER, LV_RADIUS_CIRCLE);
+    info_status_label_ =
+        make_label(info_view_, "", 20, 20, 180, 16, &lv_font_montserrat_10, lv_color_hex(0xAEB2B8), LV_TEXT_ALIGN_LEFT);
+    make_label(info_view_, "CLIENT", 240, 20, 72, 16, &lv_font_montserrat_10, lv_color_hex(0x777B82),
+               LV_TEXT_ALIGN_RIGHT);
     make_divider(info_view_, 41);
-    make_label(info_view_, "DEVICE", 8, 48, 148, 11, &lv_font_montserrat_10,
-               lv_color_hex(0x777B82), LV_TEXT_ALIGN_LEFT);
-    make_label(info_view_, "RSSI", 166, 48, 66, 11, &lv_font_montserrat_10,
-               lv_color_hex(0x777B82), LV_TEXT_ALIGN_LEFT);
-    make_label(info_view_, "SNR", 240, 48, 72, 11, &lv_font_montserrat_10,
-               lv_color_hex(0x777B82), LV_TEXT_ALIGN_LEFT);
-    info_device_value_ = make_label(info_view_, "", 8, 60, 148, 17, &lv_font_montserrat_12,
-                                    lv_color_hex(0xDDE0E4), LV_TEXT_ALIGN_LEFT);
-    info_rssi_value_ = make_label(info_view_, "", 166, 60, 66, 17, &lv_font_montserrat_12,
-                                  lv_color_hex(0xDDE0E4), LV_TEXT_ALIGN_LEFT);
-    info_snr_value_ = make_label(info_view_, "", 240, 60, 72, 17, &lv_font_montserrat_12,
-                                 lv_color_hex(0xDDE0E4), LV_TEXT_ALIGN_LEFT);
+    make_label(info_view_, "DEVICE", 8, 48, 148, 11, &lv_font_montserrat_10, lv_color_hex(0x777B82),
+               LV_TEXT_ALIGN_LEFT);
+    make_label(info_view_, "RSSI", 166, 48, 66, 11, &lv_font_montserrat_10, lv_color_hex(0x777B82), LV_TEXT_ALIGN_LEFT);
+    make_label(info_view_, "SNR", 240, 48, 72, 11, &lv_font_montserrat_10, lv_color_hex(0x777B82), LV_TEXT_ALIGN_LEFT);
+    info_device_value_ =
+        make_label(info_view_, "", 8, 60, 148, 17, &lv_font_montserrat_12, lv_color_hex(0xDDE0E4), LV_TEXT_ALIGN_LEFT);
+    info_rssi_value_ =
+        make_label(info_view_, "", 166, 60, 66, 17, &lv_font_montserrat_12, lv_color_hex(0xDDE0E4), LV_TEXT_ALIGN_LEFT);
+    info_snr_value_ =
+        make_label(info_view_, "", 240, 60, 72, 17, &lv_font_montserrat_12, lv_color_hex(0xDDE0E4), LV_TEXT_ALIGN_LEFT);
     if (info_device_value_) lv_label_set_long_mode(info_device_value_, LV_LABEL_LONG_DOT);
     make_divider(info_view_, 81);
-    make_label(info_view_, "LINK", 8, 88, 304, 11, &lv_font_montserrat_10,
-               lv_color_hex(0x777B82), LV_TEXT_ALIGN_LEFT);
-    info_link_value_ = make_label(info_view_, "", 8, 100, 304, 16, &lv_font_montserrat_12,
-                                  lv_color_hex(0xDDE0E4), LV_TEXT_ALIGN_LEFT);
-    info_diag_value_ = make_label(info_view_, "", 8, 120, 304, 13, &lv_font_montserrat_10,
-                                  lv_color_hex(0x777B82), LV_TEXT_ALIGN_LEFT);
+    make_label(info_view_, "LINK", 8, 88, 304, 11, &lv_font_montserrat_10, lv_color_hex(0x777B82), LV_TEXT_ALIGN_LEFT);
+    info_link_value_ =
+        make_label(info_view_, "", 8, 100, 304, 16, &lv_font_montserrat_12, lv_color_hex(0xDDE0E4), LV_TEXT_ALIGN_LEFT);
+    info_diag_value_ =
+        make_label(info_view_, "", 8, 120, 304, 13, &lv_font_montserrat_10, lv_color_hex(0x777B82), LV_TEXT_ALIGN_LEFT);
     if (info_link_value_) lv_label_set_long_mode(info_link_value_, LV_LABEL_LONG_DOT);
     if (info_diag_value_) lv_label_set_long_mode(info_diag_value_, LV_LABEL_LONG_DOT);
 }
@@ -441,90 +416,90 @@ void UILoraPage::create_send_view()
     send_view_ = make_plain_container(page_root_, 0, 0, 320, 150);
     if (!send_view_) return;
     lv_obj_add_event_cb(send_view_, static_owned_obj_delete_cb, LV_EVENT_DELETE, this);
-    make_label(send_view_, "New Message", 0, 0, 320, 18, &lv_font_montserrat_14,
-               lv_color_hex(0xE4E4E4), LV_TEXT_ALIGN_CENTER);
-    send_input_bubble_ = make_panel(send_view_, 0, 0, 286, 80, lv_color_hex(0x555555),
-                                    LV_OPA_COVER, 8);
+    make_label(send_view_, "New Message", 0, 0, 320, 18, &lv_font_montserrat_14, lv_color_hex(0xE4E4E4),
+               LV_TEXT_ALIGN_CENTER);
+    send_input_bubble_ = make_panel(send_view_, 0, 0, 286, 80, lv_color_hex(0x555555), LV_OPA_COVER, 8);
     if (send_input_bubble_) lv_obj_align(send_input_bubble_, LV_ALIGN_CENTER, 0, -12);
-    send_input_label_ = make_label(send_input_bubble_, "", 10, 8, 266, 64,
-                                   &lv_font_montserrat_14, lv_color_hex(0xFFFFFF),
-                                   LV_TEXT_ALIGN_LEFT);
-    send_status_label_ = make_label(send_input_bubble_, "", 10, 54, 266, 16,
-                                    &lv_font_montserrat_14, lv_color_hex(0xFED40D),
-                                    LV_TEXT_ALIGN_RIGHT);
+    send_input_label_  = make_label(send_input_bubble_, "", 10, 8, 266, 64, &lv_font_montserrat_14,
+                                    lv_color_hex(0xFFFFFF), LV_TEXT_ALIGN_LEFT);
+    send_status_label_ = make_label(send_input_bubble_, "", 10, 54, 266, 16, &lv_font_montserrat_14,
+                                    lv_color_hex(0xFED40D), LV_TEXT_ALIGN_RIGHT);
     set_visible(send_status_label_, false);
-    send_cancel_button_ = make_action_button(send_view_, 83, 113, 110, "ESC: Cancel",
-                                              lv_color_hex(0x6D6D6D), lv_color_hex(0xF3F3F3),
-                                              &UILoraPage::static_cancel_button_cb);
-    send_confirm_button_ = make_action_button(send_view_, 203, 113, 100, "Enter: Send",
-                                               lv_color_hex(0xFED40D), lv_color_hex(0x5E4D00),
-                                               &UILoraPage::static_send_button_cb);
+    send_cancel_button_  = make_action_button(send_view_, 83, 113, 110, "ESC: Cancel", lv_color_hex(0x6D6D6D),
+                                              lv_color_hex(0xF3F3F3), &UILoraPage::static_cancel_button_cb);
+    send_confirm_button_ = make_action_button(send_view_, 203, 113, 100, "Enter: Send", lv_color_hex(0xFED40D),
+                                              lv_color_hex(0x5E4D00), &UILoraPage::static_send_button_cb);
 }
 
-lv_obj_t *UILoraPage::make_action_button(lv_obj_t *parent, lv_coord_t x, lv_coord_t y,
-                                         lv_coord_t width, const char *text,
-                                         lv_color_t background, lv_color_t foreground,
+lv_obj_t *UILoraPage::make_action_button(lv_obj_t *parent, lv_coord_t x, lv_coord_t y, lv_coord_t width,
+                                         const char *text, lv_color_t background, lv_color_t foreground,
                                          lv_event_cb_t callback)
 {
     lv_obj_t *button = make_panel(parent, x, y, width, 26, background, LV_OPA_COVER, 5);
     if (!button) return nullptr;
     lv_obj_add_flag(button, LV_OBJ_FLAG_CLICKABLE);
     lv_obj_add_event_cb(button, callback, LV_EVENT_CLICKED, this);
-    lv_obj_t *label = make_label(button, text, 0, 0, LV_SIZE_CONTENT, LV_SIZE_CONTENT,
-                                 &lv_font_montserrat_14, foreground, LV_TEXT_ALIGN_CENTER);
+    lv_obj_t *label = make_label(button, text, 0, 0, LV_SIZE_CONTENT, LV_SIZE_CONTENT, &lv_font_montserrat_14,
+                                 foreground, LV_TEXT_ALIGN_CENTER);
     if (label) lv_obj_center(label);
     return button;
 }
 
 void UILoraPage::create_page_indicator()
 {
-    page_indicator_ = make_panel(page_root_, 141, 137, 38, 24, lv_color_hex(0x0B0C0E),
-                                 LV_OPA_COVER, 7);
+    page_indicator_ = make_panel(page_root_, 141, 137, 38, 24, lv_color_hex(0x0B0C0E), LV_OPA_COVER, 7);
     if (!page_indicator_) return;
     lv_obj_add_event_cb(page_indicator_, static_owned_obj_delete_cb, LV_EVENT_DELETE, this);
-    page_dots_[0] = make_panel(page_indicator_, 11, 3, 5, 5, lv_color_hex(0xE4E4E4),
-                               LV_OPA_COVER, LV_RADIUS_CIRCLE);
-    page_dots_[1] = make_panel(page_indicator_, 22, 3, 5, 5, lv_color_hex(0x4E5157),
-                               LV_OPA_COVER, LV_RADIUS_CIRCLE);
+    page_dots_[0] = make_panel(page_indicator_, 11, 3, 5, 5, lv_color_hex(0xE4E4E4), LV_OPA_COVER, LV_RADIUS_CIRCLE);
+    page_dots_[1] = make_panel(page_indicator_, 22, 3, 5, 5, lv_color_hex(0x4E5157), LV_OPA_COVER, LV_RADIUS_CIRCLE);
 }
 
 void UILoraPage::bind_events()
 {
-    if (root_screen_)
-        lv_obj_add_event_cb(root_screen_, &UILoraPage::static_key_event_cb, LV_EVENT_ALL, this);
+    if (root_screen_) lv_obj_add_event_cb(root_screen_, &UILoraPage::static_key_event_cb, LV_EVENT_ALL, this);
 }
 
 void UILoraPage::track_owned_handle(lv_obj_t *object)
 {
-    if (object)
-        lv_obj_add_event_cb(object, static_owned_obj_delete_cb, LV_EVENT_DELETE, this);
+    if (object) lv_obj_add_event_cb(object, static_owned_obj_delete_cb, LV_EVENT_DELETE, this);
 }
 
 bool UILoraPage::ui_ready() const
 {
     return lora_page_controls_ready(
-        page_root_, messages_view_, message_list_, empty_message_label_,
-        empty_message_hint_label_, info_view_, info_status_dot_, info_status_label_,
-        info_device_value_, info_rssi_value_, info_snr_value_, info_link_value_,
-        info_diag_value_, send_view_, send_input_bubble_, send_input_label_,
-        send_status_label_, send_cancel_button_, send_confirm_button_, page_indicator_,
-        page_dots_[0], page_dots_[1]);
+        page_root_, messages_view_, message_list_, empty_message_label_, empty_message_hint_label_, info_view_,
+        info_status_dot_, info_status_label_, info_device_value_, info_rssi_value_, info_snr_value_, info_link_value_,
+        info_diag_value_, send_view_, send_input_bubble_, send_input_label_, send_status_label_, send_cancel_button_,
+        send_confirm_button_, page_indicator_, page_dots_[0], page_dots_[1]);
 }
 
 void UILoraPage::detach_delete_callbacks()
 {
-    lv_obj_t *objects[] = {
-        message_list_, messages_view_, empty_message_label_, empty_message_hint_label_,
-        messages_title_,
-        info_view_, info_status_dot_, info_status_label_, info_device_value_,
-        info_rssi_value_, info_snr_value_, info_link_value_, info_diag_value_,
-        send_view_, send_input_bubble_, send_input_label_, send_status_label_,
-        send_cancel_button_, send_confirm_button_, page_indicator_, page_dots_[0],
-        page_dots_[1], page_root_};
+    lv_obj_t *objects[] = {message_list_,
+                           messages_view_,
+                           empty_message_label_,
+                           empty_message_hint_label_,
+                           messages_title_,
+                           info_view_,
+                           info_status_dot_,
+                           info_status_label_,
+                           info_device_value_,
+                           info_rssi_value_,
+                           info_snr_value_,
+                           info_link_value_,
+                           info_diag_value_,
+                           send_view_,
+                           send_input_bubble_,
+                           send_input_label_,
+                           send_status_label_,
+                           send_cancel_button_,
+                           send_confirm_button_,
+                           page_indicator_,
+                           page_dots_[0],
+                           page_dots_[1],
+                           page_root_};
     for (lv_obj_t *object : objects)
-        if (object)
-            lv_obj_remove_event_cb_with_user_data(
-                object, static_owned_obj_delete_cb, this);
+        if (object) lv_obj_remove_event_cb_with_user_data(object, static_owned_obj_delete_cb, this);
 }
 
 void UILoraPage::clear_deleted_handles(lv_obj_t *deleted)
@@ -551,68 +526,68 @@ void UILoraPage::clear_deleted_handles(lv_obj_t *deleted)
     if (deleted == page_dots_[0]) page_dots_[0] = nullptr;
     if (deleted == page_dots_[1]) page_dots_[1] = nullptr;
     if (deleted == message_list_) {
-        message_list_ = nullptr;
+        message_list_     = nullptr;
         last_message_row_ = nullptr;
     }
     if (deleted == messages_view_) {
         cancel_message_title_animation();
-        messages_view_ = nullptr;
-        message_list_ = nullptr;
-        messages_title_ = nullptr;
-        empty_message_label_ = nullptr;
+        messages_view_            = nullptr;
+        message_list_             = nullptr;
+        messages_title_           = nullptr;
+        empty_message_label_      = nullptr;
         empty_message_hint_label_ = nullptr;
-        last_message_row_ = nullptr;
+        last_message_row_         = nullptr;
     }
     if (deleted == info_view_) {
-        info_view_ = nullptr;
-        info_status_dot_ = nullptr;
+        info_view_         = nullptr;
+        info_status_dot_   = nullptr;
         info_status_label_ = nullptr;
         info_device_value_ = nullptr;
-        info_rssi_value_ = nullptr;
-        info_snr_value_ = nullptr;
-        info_link_value_ = nullptr;
-        info_diag_value_ = nullptr;
+        info_rssi_value_   = nullptr;
+        info_snr_value_    = nullptr;
+        info_link_value_   = nullptr;
+        info_diag_value_   = nullptr;
     }
     if (deleted == send_view_) {
-        send_view_ = nullptr;
-        send_input_bubble_ = nullptr;
-        send_input_label_ = nullptr;
-        send_status_label_ = nullptr;
-        send_cancel_button_ = nullptr;
+        send_view_           = nullptr;
+        send_input_bubble_   = nullptr;
+        send_input_label_    = nullptr;
+        send_status_label_   = nullptr;
+        send_cancel_button_  = nullptr;
         send_confirm_button_ = nullptr;
     }
     if (deleted == page_indicator_) {
         page_indicator_ = nullptr;
-        page_dots_[0] = nullptr;
-        page_dots_[1] = nullptr;
+        page_dots_[0]   = nullptr;
+        page_dots_[1]   = nullptr;
     }
     if (active_view_ == deleted) active_view_ = nullptr;
     if (deleted == page_root_) {
-        page_root_ = nullptr;
-        messages_view_ = nullptr;
-        message_list_ = nullptr;
-        empty_message_label_ = nullptr;
+        page_root_                = nullptr;
+        messages_view_            = nullptr;
+        message_list_             = nullptr;
+        empty_message_label_      = nullptr;
         empty_message_hint_label_ = nullptr;
-        last_message_row_ = nullptr;
-        info_view_ = nullptr;
-        info_status_dot_ = nullptr;
-        info_status_label_ = nullptr;
-        info_device_value_ = nullptr;
-        info_rssi_value_ = nullptr;
-        info_snr_value_ = nullptr;
-        info_link_value_ = nullptr;
-        info_diag_value_ = nullptr;
-        send_view_ = nullptr;
-        send_input_bubble_ = nullptr;
-        send_input_label_ = nullptr;
-        send_status_label_ = nullptr;
-        send_cancel_button_ = nullptr;
-        send_confirm_button_ = nullptr;
-        page_indicator_ = nullptr;
-        page_dots_[0] = nullptr;
-        page_dots_[1] = nullptr;
-        active_view_ = nullptr;
-        app_active_ = false;
+        last_message_row_         = nullptr;
+        info_view_                = nullptr;
+        info_status_dot_          = nullptr;
+        info_status_label_        = nullptr;
+        info_device_value_        = nullptr;
+        info_rssi_value_          = nullptr;
+        info_snr_value_           = nullptr;
+        info_link_value_          = nullptr;
+        info_diag_value_          = nullptr;
+        send_view_                = nullptr;
+        send_input_bubble_        = nullptr;
+        send_input_label_         = nullptr;
+        send_status_label_        = nullptr;
+        send_cancel_button_       = nullptr;
+        send_confirm_button_      = nullptr;
+        page_indicator_           = nullptr;
+        page_dots_[0]             = nullptr;
+        page_dots_[1]             = nullptr;
+        active_view_              = nullptr;
+        app_active_               = false;
         cancel_message_title_animation();
         messages_title_ = nullptr;
         poll_timer_.stop();
@@ -626,14 +601,14 @@ void UILoraPage::clear_deleted_handles(lv_obj_t *deleted)
 void UILoraPage::static_owned_obj_delete_cb(lv_event_t *event) noexcept
 {
     try {
-        if (!event || !lora_owned_delete_callback_allowed(
-                lv_event_get_target(event), lv_event_get_current_target(event))) return;
-        auto *self = static_cast<UILoraPage *>(lv_event_get_user_data(event));
+        if (!event ||
+            !lora_owned_delete_callback_allowed(lv_event_get_target(event), lv_event_get_current_target(event)))
+            return;
+        auto *self    = static_cast<UILoraPage *>(lv_event_get_user_data(event));
         auto *deleted = static_cast<lv_obj_t *>(lv_event_get_target(event));
         if (self) self->clear_deleted_handles(deleted);
     } catch (...) {
-        auto *self = event
-            ? static_cast<UILoraPage *>(lv_event_get_user_data(event)) : nullptr;
+        auto *self = event ? static_cast<UILoraPage *>(lv_event_get_user_data(event)) : nullptr;
         if (self) self->app_active_ = false;
     }
 }
@@ -642,62 +617,50 @@ lv_obj_t *UILoraPage::append_message_row(const LoraChatMessage &message)
 {
     if (!message_list_) return nullptr;
     char metadata[64] = "";
-    if (!message.outgoing)
-        std::snprintf(metadata, sizeof(metadata), "%.0f dBm  /  %.1f dB",
-                      message.rssi, message.snr);
+    if (!message.outgoing) std::snprintf(metadata, sizeof(metadata), "%.0f dBm  /  %.1f dB", message.rssi, message.snr);
 
     static constexpr int32_t HORIZONTAL_PADDING = 10;
-    static constexpr int32_t MAX_TEXT_WIDTH = 224;
-    static constexpr int32_t MAX_BUBBLE_WIDTH = 244;
+    static constexpr int32_t MAX_TEXT_WIDTH     = 224;
+    static constexpr int32_t MAX_BUBBLE_WIDTH   = 244;
     lv_point_t text_size{};
-    lv_text_get_size(&text_size, message.text.c_str(), &lv_font_montserrat_12, 0, 0,
-                     MAX_TEXT_WIDTH, LV_TEXT_FLAG_NONE);
+    lv_text_get_size(&text_size, message.text.c_str(), &lv_font_montserrat_12, 0, 0, MAX_TEXT_WIDTH, LV_TEXT_FLAG_NONE);
     int32_t content_width = text_size.x;
     if (metadata[0]) {
         lv_point_t metadata_size{};
-        lv_text_get_size(&metadata_size, metadata, &lv_font_montserrat_10, 0, 0,
-                         MAX_TEXT_WIDTH, LV_TEXT_FLAG_NONE);
+        lv_text_get_size(&metadata_size, metadata, &lv_font_montserrat_10, 0, 0, MAX_TEXT_WIDTH, LV_TEXT_FLAG_NONE);
         content_width = std::max(content_width, metadata_size.x);
     }
-    int32_t bubble_width = std::max<int32_t>(
-        64, std::min<int32_t>(MAX_BUBBLE_WIDTH, content_width + HORIZONTAL_PADDING * 2));
+    int32_t bubble_width =
+        std::max<int32_t>(64, std::min<int32_t>(MAX_BUBBLE_WIDTH, content_width + HORIZONTAL_PADDING * 2));
 
     lv_obj_t *row = make_plain_container(message_list_, 0, 0, LV_PCT(100), LV_SIZE_CONTENT);
     if (!row) return nullptr;
     lv_obj_set_flex_flow(row, LV_FLEX_FLOW_ROW);
-    lv_obj_set_flex_align(row,
-                          message.outgoing ? LV_FLEX_ALIGN_END : LV_FLEX_ALIGN_START,
-                          LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+    lv_obj_set_flex_align(row, message.outgoing ? LV_FLEX_ALIGN_END : LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START,
+                          LV_FLEX_ALIGN_START);
     if (message.outgoing) lv_obj_add_flag(row, LV_OBJ_FLAG_USER_1);
     lv_obj_add_event_cb(row, bubble_tail_draw_cb, LV_EVENT_DRAW_MAIN_END, nullptr);
 
     lv_obj_t *bubble = make_panel(row, 0, 0, bubble_width, LV_SIZE_CONTENT,
-                                  lv_color_hex(message.outgoing ? 0x3FCC75 : 0xCCCCCC),
-                                  LV_OPA_COVER, 8);
+                                  lv_color_hex(message.outgoing ? 0x3FCC75 : 0xCCCCCC), LV_OPA_COVER, 8);
     if (!bubble) return row;
-    lv_obj_set_style_margin_left(bubble,
-                                 message.outgoing ? 0 : lora_app_detail::kBubbleTailWidth,
+    lv_obj_set_style_margin_left(bubble, message.outgoing ? 0 : lora_app_detail::kBubbleTailWidth,
                                  LV_PART_MAIN | LV_STATE_DEFAULT);
-    lv_obj_set_style_margin_right(bubble,
-                                  message.outgoing ? lora_app_detail::kBubbleTailWidth : 0,
+    lv_obj_set_style_margin_right(bubble, message.outgoing ? lora_app_detail::kBubbleTailWidth : 0,
                                   LV_PART_MAIN | LV_STATE_DEFAULT);
-    lv_obj_set_style_margin_bottom(bubble, lora_app_detail::kBubbleTailDrop,
-                                   LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_margin_bottom(bubble, lora_app_detail::kBubbleTailDrop, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_flex_flow(bubble, LV_FLEX_FLOW_COLUMN);
-    lv_obj_set_flex_align(bubble, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START,
-                          LV_FLEX_ALIGN_START);
+    lv_obj_set_flex_align(bubble, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
     lv_obj_set_style_pad_left(bubble, HORIZONTAL_PADDING, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_pad_right(bubble, HORIZONTAL_PADDING, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_pad_top(bubble, 7, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_pad_bottom(bubble, 7, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_pad_row(bubble, 3, LV_PART_MAIN | LV_STATE_DEFAULT);
 
-    make_label(bubble, message.text.c_str(), 0, 0,
-               bubble_width - HORIZONTAL_PADDING * 2, LV_SIZE_CONTENT,
+    make_label(bubble, message.text.c_str(), 0, 0, bubble_width - HORIZONTAL_PADDING * 2, LV_SIZE_CONTENT,
                &lv_font_montserrat_12, lv_color_hex(0x000000), LV_TEXT_ALIGN_LEFT);
     if (metadata[0])
-        make_label(bubble, metadata, 0, 0, bubble_width - HORIZONTAL_PADDING * 2,
-                   LV_SIZE_CONTENT, &lv_font_montserrat_10, lv_color_hex(0x7E7E7E),
-                   LV_TEXT_ALIGN_RIGHT);
+        make_label(bubble, metadata, 0, 0, bubble_width - HORIZONTAL_PADDING * 2, LV_SIZE_CONTENT,
+                   &lv_font_montserrat_10, lv_color_hex(0x7E7E7E), LV_TEXT_ALIGN_RIGHT);
     return row;
 }

--- a/projects/APPLaunch/main/ui/page_app/ui_app_lora_view.cpp
+++ b/projects/APPLaunch/main/ui/page_app/ui_app_lora_view.cpp
@@ -12,6 +12,10 @@ namespace lora_app_detail {
 constexpr lv_coord_t kScreenWidth = 320;
 constexpr lv_coord_t kContentHeight = 150;
 constexpr uint32_t kViewTransitionMs = 150;
+constexpr uint32_t kMessageTitleHoldMs = 3200;
+constexpr uint32_t kMessageTitleHideMs = 340;
+constexpr lv_coord_t kMessageTitleShownY = -8;
+constexpr lv_coord_t kMessageTitleHiddenY = -29;
 constexpr lv_coord_t kBubbleTailWidth = 6;
 constexpr lv_coord_t kBubbleTailDrop = 3;
 
@@ -186,6 +190,70 @@ void UILoraPage::scroll_to_latest(lv_anim_enable_t animation)
     scroll_to_latest_pending_ = false;
 }
 
+void UILoraPage::schedule_message_title_dismissal()
+{
+    if (!messages_title_ || message_title_timer_ ||
+        lv_obj_has_flag(messages_title_, LV_OBJ_FLAG_HIDDEN))
+        return;
+
+    message_title_timer_ = lv_timer_create(
+        &UILoraPage::static_message_title_timer_cb, lora_app_detail::kMessageTitleHoldMs, this);
+    if (message_title_timer_)
+        lv_timer_set_repeat_count(message_title_timer_, 1);
+}
+
+void UILoraPage::cancel_message_title_animation()
+{
+    if (message_title_timer_) {
+        lv_timer_delete(message_title_timer_);
+        message_title_timer_ = nullptr;
+    }
+    if (messages_title_)
+        lv_anim_del(messages_title_, &UILoraPage::message_title_anim_exec_cb);
+}
+
+void UILoraPage::dismiss_message_title()
+{
+    if (!messages_title_ || lv_obj_has_flag(messages_title_, LV_OBJ_FLAG_HIDDEN))
+        return;
+
+    if (message_title_timer_) {
+        lv_timer_delete(message_title_timer_);
+        message_title_timer_ = nullptr;
+    }
+
+    lv_anim_del(messages_title_, &UILoraPage::message_title_anim_exec_cb);
+    lv_anim_t animation;
+    lv_anim_init(&animation);
+    lv_anim_set_var(&animation, messages_title_);
+    lv_anim_set_values(&animation, lv_obj_get_y(messages_title_),
+                       lora_app_detail::kMessageTitleHiddenY);
+    lv_anim_set_time(&animation, lora_app_detail::kMessageTitleHideMs);
+    lv_anim_set_path_cb(&animation, lv_anim_path_ease_out);
+    lv_anim_set_exec_cb(&animation, &UILoraPage::message_title_anim_exec_cb);
+    lv_anim_set_user_data(&animation, messages_title_);
+    lv_anim_set_completed_cb(&animation, &UILoraPage::hide_message_title_after_anim_cb);
+    if (!lv_anim_start(&animation)) {
+        message_title_anim_exec_cb(messages_title_, lora_app_detail::kMessageTitleHiddenY);
+        set_visible(messages_title_, false);
+    }
+}
+
+void UILoraPage::message_title_anim_exec_cb(void *object, int32_t y) noexcept
+{
+    if (!object) return;
+    lv_obj_set_y(static_cast<lv_obj_t *>(object), static_cast<lv_coord_t>(y));
+}
+
+void UILoraPage::hide_message_title_after_anim_cb(lv_anim_t *animation) noexcept
+{
+    if (!animation) return;
+    auto *title = static_cast<lv_obj_t *>(lv_anim_get_user_data(animation));
+    if (!lora_animation_callback_allowed(title)) return;
+    message_title_anim_exec_cb(title, lora_app_detail::kMessageTitleHiddenY);
+    set_visible(title, false);
+}
+
 void UILoraPage::view_opa_exec_cb(void *object, int32_t opacity) noexcept
 {
     if (!lora_animation_callback_allowed(object)) return;
@@ -293,7 +361,7 @@ void UILoraPage::create_ui()
         info_status_label_, info_device_value_, info_rssi_value_, info_snr_value_,
         info_link_value_, info_diag_value_, send_input_bubble_, send_input_label_,
         send_status_label_, send_cancel_button_, send_confirm_button_, page_dots_[0],
-        page_dots_[1]};
+        page_dots_[1], messages_title_};
     for (lv_obj_t *object : persistent_children) track_owned_handle(object);
 }
 
@@ -323,10 +391,10 @@ void UILoraPage::create_messages_view()
     empty_message_hint_label_ = make_label(messages_view_, "Type anything to send", 0, 68,
                                            320, 14, &lv_font_montserrat_12,
                                            lv_color_hex(0x5FE492), LV_TEXT_ALIGN_CENTER);
-    lv_obj_t *title = make_panel(messages_view_, 108, -8, 104, 28,
-                                 lv_color_hex(0x0B0C0E), LV_OPA_COVER, 8);
-    if (title)
-        make_label(title, "Messages", 0, 8, 104, 18, &lv_font_montserrat_14,
+    messages_title_ = make_panel(messages_view_, 108, lora_app_detail::kMessageTitleShownY,
+                                 104, 28, lv_color_hex(0x0B0C0E), LV_OPA_COVER, 8);
+    if (messages_title_)
+        make_label(messages_title_, "Messages", 0, 8, 104, 18, &lv_font_montserrat_14,
                    lv_color_hex(0xE4E4E4), LV_TEXT_ALIGN_CENTER);
 }
 
@@ -447,6 +515,7 @@ void UILoraPage::detach_delete_callbacks()
 {
     lv_obj_t *objects[] = {
         message_list_, messages_view_, empty_message_label_, empty_message_hint_label_,
+        messages_title_,
         info_view_, info_status_dot_, info_status_label_, info_device_value_,
         info_rssi_value_, info_snr_value_, info_link_value_, info_diag_value_,
         send_view_, send_input_bubble_, send_input_label_, send_status_label_,
@@ -461,6 +530,10 @@ void UILoraPage::detach_delete_callbacks()
 void UILoraPage::clear_deleted_handles(lv_obj_t *deleted)
 {
     if (!deleted) return;
+    if (deleted == messages_title_) {
+        lv_anim_del(deleted, &UILoraPage::message_title_anim_exec_cb);
+        messages_title_ = nullptr;
+    }
     if (deleted == empty_message_label_) empty_message_label_ = nullptr;
     if (deleted == empty_message_hint_label_) empty_message_hint_label_ = nullptr;
     if (deleted == info_status_dot_) info_status_dot_ = nullptr;
@@ -482,8 +555,10 @@ void UILoraPage::clear_deleted_handles(lv_obj_t *deleted)
         last_message_row_ = nullptr;
     }
     if (deleted == messages_view_) {
+        cancel_message_title_animation();
         messages_view_ = nullptr;
         message_list_ = nullptr;
+        messages_title_ = nullptr;
         empty_message_label_ = nullptr;
         empty_message_hint_label_ = nullptr;
         last_message_row_ = nullptr;
@@ -538,6 +613,8 @@ void UILoraPage::clear_deleted_handles(lv_obj_t *deleted)
         page_dots_[1] = nullptr;
         active_view_ = nullptr;
         app_active_ = false;
+        cancel_message_title_animation();
+        messages_title_ = nullptr;
         poll_timer_.stop();
     }
     if (!ui_ready()) {


### PR DESCRIPTION
- Make LoRa initialization asynchronous.
- Fix Shift/Fn key events being inserted as characters.
- Adjust TX timeout for long LoRa packets.
- Clean up failed TX and initialization states.
- Auto-hide the Messages title when new messages arrive.
