### PR TITLE
    fix(wizard): restore marker-triggered OOBE before service handoff

### DIFF
--- a/projects/LaunchWizard/main/ui/first_boot_policy.cpp
+++ b/projects/LaunchWizard/main/ui/first_boot_policy.cpp
@@ -7,7 +7,7 @@ bool should_run_wizard(const FirstBootState &state)
     if (state.rearm_marker)
         return true;
     if (state.factory_marker)
-        return !state.user_has_password;
+        return true;
     return state.legacy_piwiz_active;
 }
 

--- a/projects/LaunchWizard/main/ui/first_boot_policy.h
+++ b/projects/LaunchWizard/main/ui/first_boot_policy.h
@@ -11,17 +11,14 @@ struct FirstBootState {
     bool rearm_marker = false;
     // /var/lib/LaunchWizard/run-oobe: baked into every factory image by pi-gen.
     bool factory_marker = false;
-    // The UID 1000 user's shadow entry holds a real "$..." hash, meaning the
-    // account was configured (Raspberry Pi Imager, a finished OOBE, ...).
-    bool user_has_password = false;
     // Legacy piwiz/lightdm first-boot autologin is still armed.
     bool legacy_piwiz_active = false;
 };
 
-// A user-requested re-run always shows the wizard. The factory marker only
-// shows it while no account has been configured yet: a device provisioned
-// through Raspberry Pi Imager already has a password, so first boot must skip
-// straight to the launcher.
+// The wizard runs when either OOBE marker is present (a user-requested re-run
+// or a factory first boot), or when the legacy piwiz/lightdm first-boot
+// autologin is still armed. LaunchWizard.service is only disabled after the
+// wizard finishes configuration (apply_all).
 bool should_run_wizard(const FirstBootState &state);
 
 // The keyboard guide runs exactly once per device, before and independently of

--- a/projects/LaunchWizard/main/ui/wizard_service.cpp
+++ b/projects/LaunchWizard/main/ui/wizard_service.cpp
@@ -1002,12 +1002,10 @@ bool launch_wizard::WizardService::should_run()
     // apply_all() clears it on completion, so the wizard still runs exactly
     // once.
     state.rearm_marker = access(kRearmOobeMarker, F_OK) == 0;
-    // pi-gen bakes the factory marker into every image. It must only trigger
-    // the OOBE while the account is still unconfigured; a device provisioned
-    // through Raspberry Pi Imager already has a password and skips straight to
-    // the launcher (finish_configured_system() then removes the marker).
+    // pi-gen bakes the factory marker into every image. Any marker means the
+    // OOBE must run; only apply_all() disables LaunchWizard.service after the
+    // user completes configuration.
     state.factory_marker = access(kFactoryOobeMarker, F_OK) == 0;
-    state.user_has_password = first_user_has_password();
     state.legacy_piwiz_active =
         lightdm_autologin_user() == kFirstBootWizardUser && piwiz_autostart_enabled();
     return should_run_wizard(state);

--- a/projects/LaunchWizard/tests/test_first_boot_policy.cpp
+++ b/projects/LaunchWizard/tests/test_first_boot_policy.cpp
@@ -23,14 +23,10 @@ bool test_first_boot_policy()
     bool passed = true;
     launch_wizard::FirstBootState state;
 
-    // Factory first boot: marker present, account unconfigured -> wizard.
+    // Factory first boot: marker present -> wizard, regardless of whether the
+    // account already has a password. Only apply_all() disables the service.
     state.factory_marker = true;
-    passed &= expect_wizard(true, state, "factory unconfigured");
-
-    // Imager-provisioned device: factory marker still present, but the user
-    // already has a password -> skip straight to the launcher (bug #227).
-    state.user_has_password = true;
-    passed &= expect_wizard(false, state, "factory imager-provisioned");
+    passed &= expect_wizard(true, state, "factory marker");
 
     // Settings "Run Setup Wizard" re-arm always wins, even when configured.
     state.rearm_marker = true;
@@ -41,8 +37,6 @@ bool test_first_boot_policy()
     passed &= expect_wizard(false, state, "no markers");
     state.legacy_piwiz_active = true;
     passed &= expect_wizard(true, state, "legacy piwiz");
-    state.user_has_password = true;
-    passed &= expect_wizard(true, state, "legacy piwiz ignores password");
 
     // Keyboard guide: needs both the marker and the installed binary; a
     // missing binary keeps the marker for a later boot.


### PR DESCRIPTION
    The first-boot keyboard guide PR made the factory OOBE marker
    (/var/lib/LaunchWizard/run-oobe) skip the wizard when UID 1000 already
    has a password, handing off to APPLaunch and disabling
    LaunchWizard.service immediately on boot. Restore the original rule:
    any OOBE marker makes should_run() true, and LaunchWizard.service is
    only disabled by apply_all() after the user completes the wizard.