### PR TITLE
fix(settings): hide camera entry and adjust ZClaw dialog

### DIFF
--- a/projects/APPLaunch/main/ui/page_app/setting/menu_builder.cpp
+++ b/projects/APPLaunch/main/ui/page_app/setting/menu_builder.cpp
@@ -14,7 +14,6 @@ void build_menu(UISetupPage &page)
     access.screen().append(page, candidate);
     access.wifi().append(page, candidate);
     access.speaker().append(page, candidate);
-    access.camera().append(page, candidate);
     access.info().append(page, candidate);
     About::append(page, candidate);
     Help::append(page, candidate);

--- a/projects/ZClaw/main/ui/zclaw_input_dialog.cpp
+++ b/projects/ZClaw/main/ui/zclaw_input_dialog.cpp
@@ -7,7 +7,9 @@
 namespace zclaw {
 namespace {
 
-constexpr lv_coord_t kDialogHeight = 170 * 2 / 3;
+constexpr lv_coord_t kDialogHeight = 96;
+// Keep the original 113 px dialog top at y=57 while shortening the bottom.
+constexpr lv_coord_t kDialogTop = 57;
 
 }  // namespace
 
@@ -144,7 +146,7 @@ void InputDialog::open(const FontManager *fonts)
     dialog_ = lv_msgbox_create(lv_layer_top());
     lv_obj_add_event_cb(dialog_, dialog_deleted, LV_EVENT_DELETE, this);
     lv_obj_set_size(dialog_, 300, kDialogHeight);
-    lv_obj_align(dialog_, LV_ALIGN_BOTTOM_MID, 0, 0);
+    lv_obj_align(dialog_, LV_ALIGN_TOP_MID, 0, kDialogTop);
     lv_obj_set_style_radius(dialog_, 8, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_bg_color(dialog_, lv_color_hex(theme::kBar), LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_bg_opa(dialog_, LV_OPA_COVER, LV_PART_MAIN | LV_STATE_DEFAULT);


### PR DESCRIPTION
Hides the Camera menu entry without removing camera internals and keeps the ZClaw input dialog clear of the lower screen edge. The PR contains one commit and two intended source files.