### PR TITLE
fix(bluetooth): refresh discoverable state after scan

### DIFF
--- a/projects/APPLaunch/main/ui/page_app/setting/bluetooth.cpp
+++ b/projects/APPLaunch/main/ui/page_app/setting/bluetooth.cpp
@@ -448,6 +448,7 @@ void BluetoothUiSession::handle_list_key(UISetupPage &page, uint32_t key)
         action_operation_.abort(action_token_);
         action_busy_ = false;
         SetupPageAccess access(page);
+        refresh_status(page);
         access.set_view(SetupViewState::SUB);
         access.build_sub_view();
         break;


### PR DESCRIPTION
Refresh the Bluetooth Discoverable state after leaving the Scan view. Stop discovery first, query the current BlueZ status, and rebuild the Bluetooth submenu.