### PR TITLE
fix(wifi): avoid reconnecting the active network

### DIFF
--- a/ext_components/cp0_lvgl/src/cp0/cp0_lvgl_network.cpp
+++ b/ext_components/cp0_lvgl/src/cp0/cp0_lvgl_network.cpp
@@ -206,6 +206,11 @@ public:
         if (!ssid || !ssid[0])
             return -1;
 
+        update_status_cache();
+        const cp0_wifi_status_t current_status = get_status();
+        if (current_status.connected && std::string(current_status.ssid) == ssid)
+            return 0;
+
         constexpr const char *kActivationTimeoutSeconds = "20";
         const bool with_password = password && password[0];
         std::string output;
@@ -234,7 +239,7 @@ public:
 
         update_status_cache();
         const cp0_wifi_status_t status = get_status();
-        if (command_result == 0 && status.connected && std::string(status.ssid) == ssid) {
+        if (status.connected && std::string(status.ssid) == ssid) {
             return 0;
         }
 


### PR DESCRIPTION
## Summary

- treat connecting the currently active SSID as an idempotent success
- avoid unnecessary NetworkManager activation and accidental saved-profile cleanup
- accept the observed target SSID after the command even if nmcli reports a stale nonzero result

## Validation

- `test_network_policy.cpp` passes with `-Wall -Wextra -Werror`
- full ARM64 Launcher release package built successfully
- on-device test on CardputerZero returned success for the active SSID with zero activation commands and preserved the saved profile
- APPLaunch remained active with zero automatic restarts across three service restarts and one full device reboot
- `dpkg --audit` reported no issues