### PR TITLE
修复开机键盘引导无声音：以 pi 用户会话身份拉起 Keyboard-Guide（bug #262）

### DIFF
--- a/projects/LaunchWizard/main/ui/wizard_service.cpp
+++ b/projects/LaunchWizard/main/ui/wizard_service.cpp
@@ -1080,6 +1080,42 @@ void launch_wizard::WizardService::run_keyboard_guide()
     // The guide is a separate on-device binary; nothing to preview in SDL.
     return;
 #else
+    // The guide's key sounds use miniaudio's PulseAudio backend, which needs
+    // the UID 1000 user's pipewire-pulse socket. Spawned as root (the wizard's
+    // own identity) it has no XDG_RUNTIME_DIR, initialises no backend and runs
+    // silently (bug #262). Drop to the first user with runuser and point it at
+    // the user's session runtime dir; the user is in the video/input groups,
+    // exactly like APPLaunch, so rendering and input keep working.
+    std::vector<std::string> args;
+    struct passwd *pw = getpwuid(kDefaultUserUid);
+    if (pw && pw->pw_name) {
+        const std::string runtime_dir =
+            "/run/user/" + std::to_string(kDefaultUserUid);
+        const std::string pulse_socket = runtime_dir + "/pulse/native";
+        // A factory image ships without linger (pi-gen strips it; the wizard
+        // only enables it after the OOBE) and lightdm is disabled, so on true
+        // first boot no user session exists and pipewire-pulse would never
+        // come up. Start the session explicitly; when linger already started
+        // it this is a no-op join.
+        run_command({"systemctl", "start",
+                     "user@" + std::to_string(kDefaultUserUid) + ".service"});
+        // Give the socket-activated pipewire-pulse a moment to come up. On
+        // timeout the guide still runs, merely without sound.
+        for (int attempt = 0;
+             attempt < 50 && access(pulse_socket.c_str(), F_OK) != 0; ++attempt)
+            usleep(200 * 1000);
+        if (access(pulse_socket.c_str(), F_OK) != 0)
+            fprintf(stderr,
+                    "LaunchWizard: %s not ready; keyboard guide may be silent\n",
+                    pulse_socket.c_str());
+        args = {"/usr/sbin/runuser", "-u", pw->pw_name, "--", "/usr/bin/env",
+                "XDG_RUNTIME_DIR=" + runtime_dir, kKeyboardGuideBinary};
+    } else {
+        fprintf(stderr,
+                "LaunchWizard: UID 1000 user missing; running guide as root\n");
+        args = {kKeyboardGuideBinary};
+    }
+
     printf("LaunchWizard: starting keyboard guide\n");
     fflush(stdout);
 
@@ -1088,7 +1124,11 @@ void launch_wizard::WizardService::run_keyboard_guide()
     // (hiding the guide's logs from journald), busy-polls at 20ms, and is
     // built around a timeout. posix_spawn + blocking waitpid inherits our
     // stdio, costs nothing while waiting, and reports exec errors directly.
-    char *argv[] = {const_cast<char *>(kKeyboardGuideBinary), nullptr};
+    std::vector<char *> argv;
+    argv.reserve(args.size() + 1);
+    for (std::string &arg : args)
+        argv.push_back(arg.data());
+    argv.push_back(nullptr);
     posix_spawnattr_t attr;
     posix_spawnattr_init(&attr);
     // Give the guide default signal dispositions regardless of what the
@@ -1100,7 +1140,7 @@ void launch_wizard::WizardService::run_keyboard_guide()
 
     pid_t pid = -1;
     const int spawn_error =
-        posix_spawn(&pid, kKeyboardGuideBinary, nullptr, &attr, argv, environ);
+        posix_spawn(&pid, argv[0], nullptr, &attr, argv.data(), environ);
     posix_spawnattr_destroy(&attr);
     if (spawn_error != 0) {
         fprintf(stderr, "LaunchWizard: failed to start keyboard guide: %s\n",


### PR DESCRIPTION
## 问题
Bug #262：开机键盘引导没有按键音。引导由 LaunchWizard 以 root 身份在开机早期拉起，此时没有 `XDG_RUNTIME_DIR`，Keyboard-Guide 的 miniaudio（PulseAudio backend）静默初始化失败，全程无声。设置页有声音是因为 APPLaunch 跑在 uid 1000 的用户会话里。

## 修复
- 拉起引导前先 `systemctl start user@1000.service`（出厂镜像此时没有 linger、lightdm 也被禁用，不主动拉就永远没有用户会话）
- 等待 `/run/user/1000/pulse/native` 就绪（最长 10s，超时仍继续运行引导，只是没声音）
- 通过 `runuser -u <user> -- env XDG_RUNTIME_DIR=/run/user/1000 <guide>` 降权到首用户运行，渲染/输入权限与 APPLaunch 相同（video/input 组）
- UID 1000 不存在时回退到原来的 root 直启

## 验证
- Docker 交叉编译 LaunchWizard 通过，二进制含新逻辑
- LaunchWizard CMake 单测 100% 通过
- 实机验证：两台测试机（.150/.77）当前均不在线，待设备恢复后补验

## 配套
- Keyboard-Guide v0.1.2：kMasterVolume 5.0 → 1.5
- pi-gen：WirePlumber 出厂默认音量 0.064 → 0.42（约 75% UI 音量）

Made with [Cursor](https://cursor.com)