### PR TITLE
恢复键盘引导仅运行一次并加固音频会话启动

### DIFF
--- a/projects/LaunchWizard/main/src/main.cpp
+++ b/projects/LaunchWizard/main/src/main.cpp
@@ -33,8 +33,8 @@ int main(int argc, char *argv[])
     if (force)
         printf("LaunchWizard: test mode, bypassing first-boot detection\n");
 
-    // The keyboard tutorial always runs first on a normal (non-test) launch,
-    // whether the OOBE that follows is shown or skipped.
+    // Consume and show the keyboard tutorial first when pi-gen's one-shot
+    // marker is present, whether the OOBE itself is shown or skipped.
     if (!force)
         launch_wizard_run_keyboard_guide();
 

--- a/projects/LaunchWizard/main/ui/application.h
+++ b/projects/LaunchWizard/main/ui/application.h
@@ -13,8 +13,8 @@ void launch_wizard_ui_teardown(void);
 bool launch_wizard_should_run(void);
 int launch_wizard_finish_configured_system(void);
 
-// Shows the keyboard tutorial before the OOBE decision on every non-test
-// launch.
+// Shows the keyboard tutorial before the OOBE decision when pi-gen's one-shot
+// marker is present.
 void launch_wizard_run_keyboard_guide(void);
 
 #endif  // LAUNCH_WIZARD_APPLICATION_H

--- a/projects/LaunchWizard/main/ui/first_boot_policy.cpp
+++ b/projects/LaunchWizard/main/ui/first_boot_policy.cpp
@@ -12,4 +12,9 @@ bool should_run_wizard(const FirstBootState &state)
     return state.legacy_piwiz_active;
 }
 
+bool should_run_keyboard_guide(bool marker_present, bool binary_present)
+{
+    return marker_present && binary_present;
+}
+
 }  // namespace launch_wizard

--- a/projects/LaunchWizard/main/ui/first_boot_policy.h
+++ b/projects/LaunchWizard/main/ui/first_boot_policy.h
@@ -33,6 +33,11 @@ struct FirstBootState {
 // Imager), so first boot skips straight to the launcher.
 bool should_run_wizard(const FirstBootState &state);
 
+// The keyboard guide runs exactly once per image installation, before and
+// independently of the OOBE. If its package is missing, keep the marker so a
+// later repaired launch can still show it.
+bool should_run_keyboard_guide(bool marker_present, bool binary_present);
+
 }  // namespace launch_wizard
 
 #endif  // LAUNCH_WIZARD_FIRST_BOOT_POLICY_H

--- a/projects/LaunchWizard/main/ui/wizard_service.cpp
+++ b/projects/LaunchWizard/main/ui/wizard_service.cpp
@@ -67,7 +67,9 @@ constexpr const char *kAccountJournalPath =
 constexpr const char *kRearmOobeMarker = "/var/lib/applaunch/run-oobe";
 // Baked into every factory image by pi-gen; removed once first boot finishes.
 constexpr const char *kFactoryOobeMarker = "/var/lib/LaunchWizard/run-oobe";
-// Keyboard tutorial shown before the OOBE on every non-test launch.
+// One-shot keyboard tutorial marker baked into the image by pi-gen.
+constexpr const char *kKeyboardGuideMarker =
+    "/var/lib/LaunchWizard/run-keyboard-guide";
 constexpr const char *kKeyboardGuideBinary =
     "/usr/share/APPLaunch/bin/M5CardputerZero-Keyboard-Guide";
 
@@ -1080,6 +1082,24 @@ void launch_wizard::WizardService::run_keyboard_guide()
     // The guide is a separate on-device binary; nothing to preview in SDL.
     return;
 #else
+    const bool marker_present = access(kKeyboardGuideMarker, F_OK) == 0;
+    const bool binary_present = access(kKeyboardGuideBinary, X_OK) == 0;
+    if (!should_run_keyboard_guide(marker_present, binary_present)) {
+        if (marker_present)
+            fprintf(stderr,
+                    "LaunchWizard: keyboard guide binary missing; keeping marker\n");
+        return;
+    }
+
+    // Consume before starting the interactive process. A power cycle or crash
+    // must not trap the device in the guide on every subsequent boot.
+    if (remove(kKeyboardGuideMarker) != 0) {
+        fprintf(stderr, "LaunchWizard: failed to consume keyboard guide marker: %s\n",
+                strerror(errno));
+        return;
+    }
+    sync();
+
     // The guide's key sounds use miniaudio's PulseAudio backend, which needs
     // the UID 1000 user's pipewire-pulse socket. Spawned as root (the wizard's
     // own identity) it has no XDG_RUNTIME_DIR, initialises no backend and runs
@@ -1089,6 +1109,7 @@ void launch_wizard::WizardService::run_keyboard_guide()
     std::vector<std::string> args;
     struct passwd *pw = getpwuid(kDefaultUserUid);
     if (pw && pw->pw_name) {
+        const std::string username = pw->pw_name;
         const std::string runtime_dir =
             "/run/user/" + std::to_string(kDefaultUserUid);
         const std::string pulse_socket = runtime_dir + "/pulse/native";
@@ -1097,8 +1118,14 @@ void launch_wizard::WizardService::run_keyboard_guide()
         // first boot no user session exists and pipewire-pulse would never
         // come up. Start the session explicitly; when linger already started
         // it this is a no-op join.
-        run_command({"systemctl", "start",
-                     "user@" + std::to_string(kDefaultUserUid) + ".service"});
+        const CommandResult session_start =
+            run_command({"systemctl", "start", "--no-block",
+                         "user@" + std::to_string(kDefaultUserUid) + ".service"});
+        if (session_start.code != 0)
+            fprintf(stderr,
+                    "LaunchWizard: failed to request user session startup: %s\n",
+                    session_start.output.empty() ? "unknown error"
+                                                 : session_start.output.c_str());
         // Give the socket-activated pipewire-pulse a moment to come up. On
         // timeout the guide still runs, merely without sound.
         for (int attempt = 0;
@@ -1108,7 +1135,8 @@ void launch_wizard::WizardService::run_keyboard_guide()
             fprintf(stderr,
                     "LaunchWizard: %s not ready; keyboard guide may be silent\n",
                     pulse_socket.c_str());
-        args = {"/usr/sbin/runuser", "-u", pw->pw_name, "--", "/usr/bin/env",
+        args = {"/usr/sbin/runuser", "-u", username, "--", "/usr/bin/env",
+                "-u", "PULSE_SERVER", "-u", "PULSE_RUNTIME_PATH",
                 "XDG_RUNTIME_DIR=" + runtime_dir, kKeyboardGuideBinary};
     } else {
         fprintf(stderr,
@@ -1149,7 +1177,14 @@ void launch_wizard::WizardService::run_keyboard_guide()
     }
 
     int status = 0;
-    while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {
+    pid_t wait_result;
+    do {
+        wait_result = waitpid(pid, &status, 0);
+    } while (wait_result < 0 && errno == EINTR);
+    if (wait_result < 0) {
+        fprintf(stderr, "LaunchWizard: wait for keyboard guide failed: %s\n",
+                strerror(errno));
+        return;
     }
     if (WIFSIGNALED(status))
         fprintf(stderr, "LaunchWizard: keyboard guide killed by signal %d\n",

--- a/projects/LaunchWizard/main/ui/wizard_service.h
+++ b/projects/LaunchWizard/main/ui/wizard_service.h
@@ -36,8 +36,8 @@ public:
     static std::string reboot();
     static bool should_run();
     static int finish_configured_system();
-    // Runs the keyboard tutorial before the OOBE decision. Returns once the
-    // guide exits or fails to start.
+    // Consumes pi-gen's one-shot marker and runs the keyboard tutorial before
+    // the OOBE decision. Returns once the guide exits or fails to start.
     static void run_keyboard_guide();
 };
 

--- a/projects/LaunchWizard/tests/test_first_boot_policy.cpp
+++ b/projects/LaunchWizard/tests/test_first_boot_policy.cpp
@@ -61,6 +61,13 @@ bool test_first_boot_policy()
     state.user_has_password = true;
     passed &= expect_wizard(true, state, "legacy piwiz ignores password");
 
+    // Keyboard guide: both marker and binary are required. In particular, a
+    // missing package must not consume the marker.
+    passed &= launch_wizard::should_run_keyboard_guide(true, true);
+    passed &= !launch_wizard::should_run_keyboard_guide(true, false);
+    passed &= !launch_wizard::should_run_keyboard_guide(false, true);
+    passed &= !launch_wizard::should_run_keyboard_guide(false, false);
+
     if (!passed)
         std::cerr << "first boot policy tests failed\n";
     return passed;


### PR DESCRIPTION
## 修复
- 恢复读取并消费 pi-gen 的 `/var/lib/LaunchWizard/run-keyboard-guide` 标记
- 服务重启及手动重跑 OOBE 不再重复显示键盘引导
- 键盘引导包缺失时保留标记，以便修复安装后补跑
- `user@1000.service` 改为非阻塞启动并记录失败原因
- 清除继承的 `PULSE_SERVER` / `PULSE_RUNTIME_PATH`
- 复制用户名，避免依赖 NSS 静态缓冲区生命周期
- 正确处理 `waitpid()` 错误

## 验证
- CardputerZero ARM64 交叉编译通过
- 一次性标记策略独立断言通过
- 仓库综合 CTest 命中既有 `command runner: a pipe-holding descendant must be reclaimed` 不稳定失败；本提交未修改 command_runner

## 发布关系
这是 bug #262 镜像发布前的阻断修复。合并后等待新的 launcher deb，再由 pi-gen 钉定该版本构建并同步 OSS Imager JSON。

Made with [Cursor](https://cursor.com)