### PR TITLE
Fix Bluetooth not automatically switching back to 'x' after scanning for a few minutes and exiting discoverable

### DIFF
--- a/projects/APPLaunch/main/ui/settings/settings_submenu_page.hpp
+++ b/projects/APPLaunch/main/ui/settings/settings_submenu_page.hpp
@@ -717,6 +717,14 @@ public:
             lv_group_add_obj(group, ComponensObj);
             lv_group_focus_obj(ComponensObj);
         }
+        for (auto it = parent_node_.begin(); it != parent_node_.end(); ++it) {
+            if (!it->icon_enabled) continue;
+            const auto index = static_cast<uint32_t>(std::distance(parent_node_.begin(), it));
+            lv_obj_t *row = ComponensObj ? lv_obj_get_child(ComponensObj, index) : nullptr;
+            if (!row) continue;
+            ++it->status_generation;
+            request_status_refresh(lv_obj_get_child(row, 1), it);
+        }        
         SetSelfUiMode(PageType::Normal);
         page3_transitioning_ = false;
         invoke_page3_animation_callback();


### PR DESCRIPTION
Fix Bluetooth not automatically switching back to 'x' after scanning for a few minutes and exiting discoverable