### PR TITLE
Fix the prompt that pops up on Bluetooth \ wifi, indicating the presence of white color blocks on the power interface

### DIFF
--- a/projects/APPLaunch/main/ui/settings/settings_bluetooth_page.cpp
+++ b/projects/APPLaunch/main/ui/settings/settings_bluetooth_page.cpp
@@ -2255,6 +2255,7 @@ LvSettingBluetoothAliasPage3::~LvSettingBluetoothAliasPage3()
         }
         if (content) {
             lv_obj_set_height(content, 32);
+            lv_obj_set_scrollbar_mode(content, LV_SCROLLBAR_MODE_OFF);
             lv_obj_set_style_bg_opa(content, LV_OPA_TRANSP, LV_PART_MAIN);
             lv_obj_set_style_border_width(content, 0, LV_PART_MAIN);
             lv_obj_set_style_pad_left(content, 12, LV_PART_MAIN);
@@ -2279,6 +2280,7 @@ LvSettingBluetoothAliasPage3::~LvSettingBluetoothAliasPage3()
             lv_obj_set_flex_align(footer, LV_FLEX_ALIGN_END, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
         }
         if (ok_button) {
+            lv_obj_remove_style(ok_button, nullptr, LV_PART_MAIN | LV_STATE_ANY);
             lv_obj_set_width(ok_button, 28);
             lv_obj_set_height(ok_button, 22);
             lv_obj_set_style_bg_opa(ok_button, LV_OPA_TRANSP, LV_PART_MAIN);

--- a/projects/APPLaunch/main/ui/settings/settings_submenu_page.cpp
+++ b/projects/APPLaunch/main/ui/settings/settings_submenu_page.cpp
@@ -251,6 +251,7 @@ void LvSettingRollerPage2::show_power_warning()
     }
     if (content) {
         lv_obj_set_height(content, 32);
+        lv_obj_set_scrollbar_mode(content, LV_SCROLLBAR_MODE_OFF);
         lv_obj_set_style_bg_opa(content, LV_OPA_TRANSP, LV_PART_MAIN);
         lv_obj_set_style_border_width(content, 0, LV_PART_MAIN);
         lv_obj_set_style_pad_left(content, 12, LV_PART_MAIN);
@@ -275,6 +276,7 @@ void LvSettingRollerPage2::show_power_warning()
         lv_obj_set_flex_align(footer, LV_FLEX_ALIGN_END, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
     }
     if (ok_button) {
+        lv_obj_remove_style(ok_button, nullptr, LV_PART_MAIN | LV_STATE_ANY);
         lv_obj_set_width(ok_button, 28);
         lv_obj_set_height(ok_button, 22);
         lv_obj_set_style_bg_opa(ok_button, LV_OPA_TRANSP, LV_PART_MAIN);

--- a/projects/APPLaunch/main/ui/settings/settings_wifi_page.cpp
+++ b/projects/APPLaunch/main/ui/settings/settings_wifi_page.cpp
@@ -869,6 +869,7 @@ void LvSettingWifiScanPage3::show_power_warning(){
             lv_obj_set_flex_align(footer, LV_FLEX_ALIGN_END, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
         }
         if (ok_button) {
+            lv_obj_remove_style(ok_button, nullptr, LV_PART_MAIN | LV_STATE_ANY);
             lv_obj_set_width(ok_button, 28);
             lv_obj_set_height(ok_button, 22);
             lv_obj_set_style_bg_opa(ok_button, LV_OPA_TRANSP, LV_PART_MAIN);


### PR DESCRIPTION
Fix the prompt that pops up on Bluetooth \ wifi, indicating the presence of white color blocks on the power interface