### PR TITLE
Point Calculator submodule to rewritten app

### DIFF
--- a/.github/workflows/launcher-build.yml
+++ b/.github/workflows/launcher-build.yml
@@ -174,7 +174,11 @@ jobs:
       run: |
         mkdir -p projects/APPLaunch/dist/bin
         cp projects/AppStore/dist/M5CardputerZero-AppStore projects/APPLaunch/dist/bin/
-        cp projects/Calculator/dist/M5CardputerZero-Calculator projects/APPLaunch/dist/bin/
+        calculator_bin=projects/Calculator/dist/M5CardputerZero-Calculator
+        if [ ! -f "$calculator_bin" ]; then
+            calculator_bin=projects/Calculator/dist/Calculator
+        fi
+        cp "$calculator_bin" projects/APPLaunch/dist/bin/M5CardputerZero-Calculator
         cp projects/ZClaw/dist/ZClaw projects/APPLaunch/dist/bin/
         mkdir -p projects/APPLaunch/dist/APPLaunch
         cp -a projects/AppStore/dist/APPLaunch/. projects/APPLaunch/dist/APPLaunch/

--- a/scripts/build_cardputerzero_release_local.sh
+++ b/scripts/build_cardputerzero_release_local.sh
@@ -105,8 +105,12 @@ echo "=== Aggregating release payload ==="
 install -d "$ROOT/projects/APPLaunch/dist/bin"
 install -m 0755 "$ROOT/projects/AppStore/dist/M5CardputerZero-AppStore" \
     "$ROOT/projects/APPLaunch/dist/bin/"
-install -m 0755 "$ROOT/projects/Calculator/dist/M5CardputerZero-Calculator" \
-    "$ROOT/projects/APPLaunch/dist/bin/"
+calculator_bin="$ROOT/projects/Calculator/dist/M5CardputerZero-Calculator"
+if [ ! -f "$calculator_bin" ]; then
+    calculator_bin="$ROOT/projects/Calculator/dist/Calculator"
+fi
+install -m 0755 "$calculator_bin" \
+    "$ROOT/projects/APPLaunch/dist/bin/M5CardputerZero-Calculator"
 install -m 0755 "$ROOT/projects/ZClaw/dist/ZClaw" \
     "$ROOT/projects/APPLaunch/dist/bin/"
 


### PR DESCRIPTION
## Summary
- Point the Calculator submodule at the rewritten CardputerZero/Calculator repository.
- Keep the legacy `M5CardputerZero-Calculator` APPLaunch executable path for seamless launcher integration.
- Accept the new canonical `Calculator` build artifact as a fallback during release aggregation.

## Test plan
- Verified Calculator unit tests.
- Verified the ARM64 Calculator build and exported compatibility ABI.
- Simulated the Launcher artifact fallback/install step.
- Checked the merge against upstream `master`.